### PR TITLE
fix(ci): ensure test jobs checkout & restore for --no-build; remove unrelated audit doc

### DIFF
--- a/.github/workflows/Ci-tests.yml
+++ b/.github/workflows/Ci-tests.yml
@@ -37,6 +37,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
+      - uses: actions/checkout@v4
       - name: Download build artifact
         uses: actions/download-artifact@v4
         with:
@@ -46,15 +47,18 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '10.0.x'
+      - name: Restore test dependencies
+        run: dotnet restore LenovoLegionToolkit.Tests/LenovoLegionToolkit.Tests.csproj
       - name: Run fast unit tests
         run: |
-          dotnet test LenovoLegionToolkit.Tests/LenovoLegionToolkit.Tests.csproj --no-restore --verbosity minimal --logger "trx;LogFileName=fast-tests.trx" --filter "TestCategory!=Integration"
+          dotnet test LenovoLegionToolkit.Tests/LenovoLegionToolkit.Tests.csproj --configuration Release --no-build --verbosity minimal --logger "trx;LogFileName=fast-tests.trx" --filter "TestCategory!=Integration"
 
   tests-slow:
     needs: build
     runs-on: windows-latest
     if: ${{ always() }}
     steps:
+      - uses: actions/checkout@v4
       - name: Download build artifact
         uses: actions/download-artifact@v4
         with:
@@ -64,6 +68,8 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '10.0.x'
+      - name: Restore test dependencies
+        run: dotnet restore LenovoLegionToolkit.Tests/LenovoLegionToolkit.Tests.csproj
       - name: Run slow/integration tests (optional)
         run: |
-          dotnet test LenovoLegionToolkit.Tests/LenovoLegionToolkit.Tests.csproj --no-restore --verbosity minimal --logger "trx;LogFileName=slow-tests.trx" --filter "TestCategory=Integration"
+          dotnet test LenovoLegionToolkit.Tests/LenovoLegionToolkit.Tests.csproj --configuration Release --no-build --verbosity minimal --logger "trx;LogFileName=slow-tests.trx" --filter "TestCategory=Integration"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 修复 LenovoLegionToolkit-Plugins/README.md 中的 workflow 路径大小写问题 / Fixed workflow path case sensitivity issues in LenovoLegionToolkit-Plugins/README.md
 - 修复 GitHub Actions CI workflow artifact 名称冲突问题，使用唯一名称 build-output-${{ github.run_id }} / Fixed GitHub Actions CI workflow artifact name conflict, using unique name build-output-${{ github.run_id }}
 - 修复 GitHub Actions CI workflow artifact 下载失败问题，简化 artifact 传递逻辑 / Fixed GitHub Actions CI workflow artifact download failure, simplified artifact transfer logic
+- 修复 CI Tests 工作流在测试作业缺少源码检出导致 `dotnet test --no-build` 失败的问题，改为在测试作业中检出源码并恢复测试依赖 / Fixed CI Tests workflow failures caused by missing source checkout in test jobs when running `dotnet test --no-build` by adding checkout and test-project restore steps
+- 修复 CI Tests 工作流在 `--no-build` 模式下未下载构建产物导致测试程序集缺失的问题，测试作业同时执行源码检出与构建产物下载 / Fixed CI Tests workflow failures caused by missing built test assemblies in `--no-build` mode by combining repository checkout with build-artifact download in test jobs
 - 调慢动画速度：Fast(0.167s) Medium(0.333s) Slow(0.5s) / Slowed down animation speeds: Fast(0.167s) Medium(0.333s) Slow(0.5s)
 - 将构建目录 build 重命名为 Build，保持命名一致性 / Renamed build directory to Build for naming consistency
 - 将构建目录 build_installer 重命名为 BuildInstaller / Renamed build_installer directory to BuildInstaller


### PR DESCRIPTION
### Motivation
- Make CI `tests-fast`/`tests-slow` reliable when running `dotnet test --no-build` by ensuring test jobs have the repository checkout, downloaded build artifacts, and test-project restore steps. 
- Remove unrelated documentation noise from the same change set to keep the PR focused on actionable CI reliability fixes.

### Description
- Updated `.github/workflows/Ci-tests.yml` to add `actions/checkout@v4` in both `tests-fast` and `tests-slow`, to ensure sources are present in test jobs. 
- Ensured test jobs download the build artifact (`actions/download-artifact@v4`) and added a `dotnet restore LenovoLegionToolkit.Tests/LenovoLegionToolkit.Tests.csproj` step before running tests. 
- Standardized test invocation to use `--configuration Release --no-build` for both fast and slow test jobs to run deterministic no-build tests against uploaded artifacts. 
- Removed the unrelated `Docs/POTENTIAL_ISSUES_AUDIT.md` file and cleaned the corresponding `CHANGELOG.md` entry so the PR focuses on CI fixes, and added two concise changelog lines describing the test-job checkout/restore and artifact-download fixes.

### Testing
- Performed a YAML parse check with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/Ci-tests.yml')"`, which succeeded. 
- Verified workflow content statically to confirm presence of `actions/checkout@v4`, `actions/download-artifact@v4`, `dotnet restore LenovoLegionToolkit.Tests/...`, and `dotnet test ... --configuration Release --no-build`. 
- Attempted to install .NET in the container using common install scripts (`curl` to dotnet install scripts) and `apt-get update`, but outbound requests were blocked by the environment (HTTP 403), so local `dotnet` validation could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699173532dec832db52c4413164959f2)