### PR TITLE
fix(plugins): tighten update and install security / 收紧插件与更新安全校验

### DIFF
--- a/.github/workflows/Ci-tests.yml
+++ b/.github/workflows/Ci-tests.yml
@@ -32,8 +32,11 @@ jobs:
       - name: Restore solution
         run: dotnet restore UniversalDeviceToolkit.sln
 
+      - name: Clean stale WPF intermediates
+        run: dotnet clean UniversalDeviceToolkit.sln --configuration Release
+
       - name: Build solution
-        run: dotnet build UniversalDeviceToolkit.sln --configuration Release --no-restore
+        run: dotnet build UniversalDeviceToolkit.sln --configuration Release --no-restore -m:1
 
       # Fast subset: tests that declare [Trait("Category", "Unit")]. Full suite below still runs everything.
       - name: Test (Unit category — fail fast)

--- a/.github/workflows/CodeQL.yml
+++ b/.github/workflows/CodeQL.yml
@@ -45,8 +45,11 @@ jobs:
       - name: Restore solution
         run: dotnet restore UniversalDeviceToolkit.sln
 
+      - name: Clean stale WPF intermediates
+        run: dotnet clean UniversalDeviceToolkit.sln --configuration Release
+
       - name: Build solution
-        run: dotnet build UniversalDeviceToolkit.sln --configuration Release --no-restore
+        run: dotnet build UniversalDeviceToolkit.sln --configuration Release --no-restore -m:1
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,11 +25,11 @@ jobs:
       - name: Restore NuGet packages
         run: dotnet restore --locked-mode
 
-      - name: Build Debug configuration
-        run: dotnet build --configuration Debug --no-restore -warnaserror -v:minimal
+      - name: Clean stale WPF intermediates
+        run: dotnet clean --configuration Debug
 
-      - name: Build Release configuration
-        run: dotnet build --configuration Release --no-restore -warnaserror -v:minimal
+      - name: Build Debug configuration
+        run: dotnet build --configuration Debug --no-restore -warnaserror -v:minimal -m:1
 
       - name: Run test suite
         run: dotnet test --configuration Debug --no-build --verbosity normal --logger "trx;LogFileName=TestResults/windows-test-results.xml"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,6 +23,8 @@
     <SupportedOSPlatformVersion>10.0.19041.0</SupportedOSPlatformVersion>
     <RestoreConfigFile Condition="'$(RestoreConfigFile)' == '' and Exists('$(MSBuildThisFileDirectory)NuGet.Config')">$(MSBuildThisFileDirectory)NuGet.Config</RestoreConfigFile>
     <DefaultItemExcludes>$(DefaultItemExcludes);**/obj-*/**</DefaultItemExcludes>
+    <UseSharedCompilation Condition="'$(GITHUB_ACTIONS)' == 'true'">false</UseSharedCompilation>
+    <NodeReuse Condition="'$(GITHUB_ACTIONS)' == 'true'">false</NodeReuse>
     <EnableUdtTestHooks Condition="'$(EnableUdtTestHooks)' == ''">false</EnableUdtTestHooks>
     <DefineConstants Condition="'$(EnableUdtTestHooks)' == 'true'">$(DefineConstants);UDT_TEST_HOOKS</DefineConstants>
   </PropertyGroup>

--- a/UniversalDeviceToolkit.Lib.Plugins/PluginLoader.cs
+++ b/UniversalDeviceToolkit.Lib.Plugins/PluginLoader.cs
@@ -677,7 +677,12 @@ public class PluginLoader : IPluginLoader
             if (assemblySimpleName.StartsWith("Wpf.Ui", StringComparison.OrdinalIgnoreCase))
                 return true;
 
-            return assemblySimpleName.StartsWith("LenovoLegionToolkit", StringComparison.OrdinalIgnoreCase) &&
+            var isHostAssembly = assemblySimpleName.StartsWith("LenovoLegionToolkit", StringComparison.OrdinalIgnoreCase) ||
+                                 assemblySimpleName.StartsWith("UniversalDeviceToolkit", StringComparison.OrdinalIgnoreCase) ||
+                                 assemblySimpleName.Equals("Universal Device Toolkit", StringComparison.OrdinalIgnoreCase) ||
+                                 assemblySimpleName.Equals("Lenovo Legion Toolkit", StringComparison.OrdinalIgnoreCase);
+
+            return isHostAssembly &&
                    !assemblySimpleName.Equals("LenovoLegionToolkit.Plugins.SDK", StringComparison.OrdinalIgnoreCase) &&
                    !assemblySimpleName.Equals("LenovoLegionToolkit.Plugins.Shared", StringComparison.OrdinalIgnoreCase);
         }

--- a/UniversalDeviceToolkit.Lib.Plugins/PluginManager.cs
+++ b/UniversalDeviceToolkit.Lib.Plugins/PluginManager.cs
@@ -2,7 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Reflection;
+using System.Text.Json;
 using System.Threading.Tasks;
 using LenovoLegionToolkit.Lib.Settings;
 using LenovoLegionToolkit.Lib.Utils;
@@ -15,6 +17,14 @@ namespace LenovoLegionToolkit.Lib.Plugins;
 /// </summary>
 public class PluginManager : IPluginManager
 {
+    private static readonly string[] OfficialPluginStoreUrls =
+    [
+        "https://cdn.jsdelivr.net/gh/SSC-STUDIO/UniversalDeviceToolkit-Plugins@master/store.json",
+        "https://raw.githubusercontent.com/SSC-STUDIO/UniversalDeviceToolkit-Plugins/master/store.json",
+        "https://cdn.jsdelivr.net/gh/SSC-STUDIO/LenovoLegionToolkit-Plugins@master/store.json",
+        "https://raw.githubusercontent.com/SSC-STUDIO/LenovoLegionToolkit-Plugins/master/store.json"
+    ];
+
     private readonly ApplicationSettings _applicationSettings;
     private readonly IPluginSignatureValidator _signatureValidator;
     private readonly IPluginLoader _loader;
@@ -1139,21 +1149,28 @@ public class PluginManager : IPluginManager
             if (Log.Instance.IsTraceEnabled)
                 Log.Instance.Trace("Checking for plugin updates...");
             
-            // Get all registered plugins
-            var plugins = _registry.GetAll();
-            
-            // For each plugin, check if there's an update (placeholder implementation)
-            // In a real app, you would connect to a plugin repository API
-            foreach (var plugin in plugins)
+            var installedVersions = _registry.GetAll()
+                .Select(plugin => new
+                {
+                    plugin.Id,
+                    Version = _registry.GetMetadata(plugin.Id)?.Version ?? "0.0.0"
+                })
+                .DistinctBy(plugin => plugin.Id, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(plugin => plugin.Id, plugin => plugin.Version, StringComparer.OrdinalIgnoreCase);
+
+            if (installedVersions.Count == 0)
+                return updates;
+
+            var availablePlugins = await FetchOfficialPluginStoreManifestsAsync().ConfigureAwait(false);
+            var versionChecker = new VersionChecker();
+
+            foreach (var availablePlugin in availablePlugins)
             {
-                var metadata = _registry.GetMetadata(plugin.Id);
-                if (metadata == null)
+                if (!installedVersions.TryGetValue(availablePlugin.Id, out var installedVersion))
                     continue;
-                
-                // This is a placeholder - actual implementation would query a repository
-                // For now, we'll just log that we're checking
-                if (Log.Instance.IsTraceEnabled)
-                    Log.Instance.Trace($"Checking updates for {plugin.Id} (v{metadata.Version})");
+
+                if (versionChecker.IsUpdateAvailable(installedVersion, availablePlugin.Version))
+                    updates[availablePlugin.Id] = availablePlugin.Version;
             }
             
             Log.Instance.Info($"Update check complete. Found {updates.Count} available updates.");
@@ -1164,6 +1181,37 @@ public class PluginManager : IPluginManager
         }
         
         return updates;
+    }
+
+    private static async Task<List<PluginManifest>> FetchOfficialPluginStoreManifestsAsync()
+    {
+        using var httpClient = new HttpClient();
+        httpClient.DefaultRequestHeaders.UserAgent.ParseAdd($"{AppIdentity.CompactName}-PluginUpdateChecker");
+
+        Exception? lastException = null;
+        foreach (var url in OfficialPluginStoreUrls)
+        {
+            try
+            {
+                var json = await httpClient.GetStringAsync(url).ConfigureAwait(false);
+                var store = JsonSerializer.Deserialize<PluginStoreResponse>(json, new JsonSerializerOptions
+                {
+                    PropertyNameCaseInsensitive = true
+                });
+
+                if (store?.Plugins is { Count: > 0 })
+                    return store.Plugins;
+            }
+            catch (Exception ex)
+            {
+                lastException = ex;
+
+                if (Log.Instance.IsTraceEnabled)
+                    Log.Instance.Trace($"Failed to fetch plugin store metadata from {url}: {ex.Message}", ex);
+            }
+        }
+
+        throw new HttpRequestException("Failed to fetch plugin store metadata from all known URLs.", lastException);
     }
     
     /// <summary>

--- a/UniversalDeviceToolkit.Lib.Plugins/PluginPaths.cs
+++ b/UniversalDeviceToolkit.Lib.Plugins/PluginPaths.cs
@@ -11,6 +11,9 @@ namespace LenovoLegionToolkit.Lib.Plugins;
 public static class PluginPaths
 {
     private static readonly string AppDataBaseDir = AppContext.BaseDirectory;
+    public const string PluginsDirectoryOverrideEnvironmentVariable = "UDT_PLUGINS_DIR";
+    public const string LegacyPluginsDirectoryOverrideEnvironmentVariable = "LLT_PLUGIN_DIRECTORY_OVERRIDE";
+    public const string LegacyPluginConfigRootEnvironmentVariable = "LLT_PLUGIN_CONFIG_ROOT";
     
     /// <summary>
     /// 插件目录名称
@@ -28,7 +31,26 @@ public static class PluginPaths
     /// <returns>插件根目录路径</returns>
     public static string GetPluginsDirectory()
     {
+        var overrideDirectory = GetPluginsDirectoryOverride();
+        if (!string.IsNullOrWhiteSpace(overrideDirectory))
+        {
+            Directory.CreateDirectory(overrideDirectory);
+            return overrideDirectory;
+        }
+
         return Folders.GetAppDataSubdirectory(PluginsDirectoryName);
+    }
+
+    private static string? GetPluginsDirectoryOverride()
+    {
+        var overrideValue = Environment.GetEnvironmentVariable(PluginsDirectoryOverrideEnvironmentVariable);
+        overrideValue ??= Environment.GetEnvironmentVariable(LegacyPluginsDirectoryOverrideEnvironmentVariable);
+        overrideValue ??= Environment.GetEnvironmentVariable(LegacyPluginConfigRootEnvironmentVariable);
+
+        if (string.IsNullOrWhiteSpace(overrideValue))
+            return null;
+
+        return Path.GetFullPath(Environment.ExpandEnvironmentVariables(overrideValue));
     }
 
     /// <summary>

--- a/UniversalDeviceToolkit.Lib.Plugins/PluginRepositoryService.cs
+++ b/UniversalDeviceToolkit.Lib.Plugins/PluginRepositoryService.cs
@@ -314,6 +314,14 @@ public class PluginRepositoryService : IDisposable
 
         foreach (var candidateUrl in candidateUrls)
         {
+            if (!IsAllowedPluginDownloadUrl(candidateUrl, manifest.Id))
+            {
+                if (Log.Instance.IsTraceEnabled)
+                    Log.Instance.Trace($"Rejected untrusted download URL for plugin {manifest.Id}: {candidateUrl}");
+
+                continue;
+            }
+
             var downloaded = await TryDownloadPluginFromUrlAsync(manifest, candidateUrl, destinationPath).ConfigureAwait(false);
             if (downloaded)
                 return new PluginDownloadResult(
@@ -354,6 +362,14 @@ public class PluginRepositoryService : IDisposable
 
             if (candidateUrl.StartsWith("file://", StringComparison.OrdinalIgnoreCase))
             {
+                if (!IsLocalDevelopmentDownloadAllowed(candidateUrl))
+                {
+                    if (Log.Instance.IsTraceEnabled)
+                        Log.Instance.Trace($"Rejected local plugin package URL outside app plugins directory: {candidateUrl}");
+
+                    return false;
+                }
+
                 var filePath = new Uri(candidateUrl).LocalPath;
                 if (!File.Exists(filePath))
                 {
@@ -1168,7 +1184,6 @@ public class PluginRepositoryService : IDisposable
         var localPluginPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "plugins", $"{manifest.Id}.zip");
         if (File.Exists(localPluginPath))
         {
-            // For local development, we need to use a file:// URL
             var uri = new Uri(localPluginPath);
             return uri.AbsoluteUri;
         }
@@ -1357,6 +1372,43 @@ public class PluginRepositoryService : IDisposable
             return IsTrustedGitHubReleaseAssetApiPath(segments);
 
         return false;
+    }
+
+    private static bool IsAllowedPluginDownloadUrl(string candidateUrl, string pluginId)
+    {
+        if (string.IsNullOrWhiteSpace(candidateUrl))
+            return false;
+
+        if (!Uri.TryCreate(candidateUrl, UriKind.Absolute, out var uri))
+            return false;
+
+        if (uri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+            return ShouldTrustDownloadedPluginPackage(candidateUrl, pluginId);
+
+        if (uri.Scheme.Equals(Uri.UriSchemeFile, StringComparison.OrdinalIgnoreCase))
+            return IsLocalDevelopmentDownloadAllowed(candidateUrl);
+
+        return false;
+    }
+
+    private static bool IsLocalDevelopmentDownloadAllowed(string candidateUrl)
+    {
+        if (!Uri.TryCreate(candidateUrl, UriKind.Absolute, out var uri) ||
+            !uri.Scheme.Equals(Uri.UriSchemeFile, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        try
+        {
+            var filePath = Path.GetFullPath(uri.LocalPath);
+            var appPluginsDirectory = Path.GetFullPath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "plugins"));
+            return PathSecurity.IsPathWithinAllowedDirectory(filePath, appPluginsDirectory);
+        }
+        catch
+        {
+            return false;
+        }
     }
 
     private static bool IsTrustedGitHubBrowserDownloadPath(IReadOnlyList<string> segments, string pluginId)

--- a/UniversalDeviceToolkit.Lib.Plugins/TrustedPluginPackageStore.cs
+++ b/UniversalDeviceToolkit.Lib.Plugins/TrustedPluginPackageStore.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
 using LenovoLegionToolkit.Lib.Utils;
 
@@ -14,6 +15,7 @@ internal static class TrustedPluginPackageStore
     private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
 
     private static string StorePath => Path.Combine(Folders.AppData, "trusted-plugin-packages.json");
+    private static string KeyPath => Path.Combine(Folders.AppData, "trusted-plugin-packages.key");
 
     public static void TrustPluginDirectory(string pluginId, string pluginDirectory)
     {
@@ -152,7 +154,16 @@ internal static class TrustedPluginPackageStore
                 return new TrustedPluginPackageStoreModel();
 
             var json = File.ReadAllText(StorePath);
-            return NormalizeStore(JsonSerializer.Deserialize<TrustedPluginPackageStoreModel>(json));
+            var store = NormalizeStore(JsonSerializer.Deserialize<TrustedPluginPackageStoreModel>(json));
+            if (!IsStoreSignatureValid(store))
+            {
+                if (Log.Instance.IsTraceEnabled)
+                    Log.Instance.Trace($"Ignoring trusted plugin package store with missing or invalid integrity signature: {StorePath}");
+
+                return new TrustedPluginPackageStoreModel();
+            }
+
+            return store;
         }
         catch
         {
@@ -178,7 +189,66 @@ internal static class TrustedPluginPackageStore
         if (!string.IsNullOrWhiteSpace(directory))
             Directory.CreateDirectory(directory);
 
+        store.Signature = string.Empty;
+        store.Signature = ComputeStoreSignature(store);
+
         File.WriteAllText(StorePath, JsonSerializer.Serialize(store, JsonOptions));
+    }
+
+    private static bool IsStoreSignatureValid(TrustedPluginPackageStoreModel store)
+    {
+        if (string.IsNullOrWhiteSpace(store.Signature))
+            return false;
+
+        var expectedSignature = ComputeStoreSignature(store);
+        return FixedTimeHexEquals(store.Signature, expectedSignature);
+    }
+
+    private static bool FixedTimeHexEquals(string left, string right)
+    {
+        try
+        {
+            return CryptographicOperations.FixedTimeEquals(
+                Convert.FromHexString(left),
+                Convert.FromHexString(right));
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static string ComputeStoreSignature(TrustedPluginPackageStoreModel store)
+    {
+        var signature = store.Signature;
+        store.Signature = string.Empty;
+        try
+        {
+            var payload = JsonSerializer.Serialize(store, JsonOptions);
+            using var hmac = new HMACSHA256(GetOrCreateStoreKey());
+            return Convert.ToHexString(hmac.ComputeHash(Encoding.UTF8.GetBytes(payload))).ToLowerInvariant();
+        }
+        finally
+        {
+            store.Signature = signature;
+        }
+    }
+
+    private static byte[] GetOrCreateStoreKey()
+    {
+        if (File.Exists(KeyPath))
+        {
+            var protectedKey = File.ReadAllBytes(KeyPath);
+            return ProtectedData.Unprotect(protectedKey, null, DataProtectionScope.CurrentUser);
+        }
+
+        var key = RandomNumberGenerator.GetBytes(32);
+        var directory = Path.GetDirectoryName(KeyPath);
+        if (!string.IsNullOrWhiteSpace(directory))
+            Directory.CreateDirectory(directory);
+
+        File.WriteAllBytes(KeyPath, ProtectedData.Protect(key, null, DataProtectionScope.CurrentUser));
+        return key;
     }
 
     private static string ComputeSha256(string filePath)
@@ -190,6 +260,7 @@ internal static class TrustedPluginPackageStore
 
     private sealed class TrustedPluginPackageStoreModel
     {
+        public string Signature { get; set; } = string.Empty;
         public Dictionary<string, TrustedPluginPackage> Plugins { get; set; } = new(StringComparer.OrdinalIgnoreCase);
     }
 

--- a/UniversalDeviceToolkit.Lib/Utils/UpdateChecker.cs
+++ b/UniversalDeviceToolkit.Lib/Utils/UpdateChecker.cs
@@ -18,6 +18,11 @@ namespace LenovoLegionToolkit.Lib.Utils;
 
 public class UpdateChecker
 {
+    private static readonly (string Owner, string Name)[] AllowedUpdateRepositories =
+    [
+        (AppIdentity.RepositoryOwner, AppIdentity.RepositoryName)
+    ];
+
     private readonly HttpClientFactory _httpClientFactory;
     private readonly UpdateCheckSettings _updateCheckSettings = IoCContainer.Resolve<UpdateCheckSettings>();
     private readonly AsyncLock _updateSemaphore = new();
@@ -79,13 +84,25 @@ public class UpdateChecker
                 var connection = new Connection(productInformation, adapter);
                 var githubClient = new GitHubClient(connection);
                 
-                // Get update repository from settings, fallback to default if not configured
-                var repositoryOwner = !string.IsNullOrWhiteSpace(_updateCheckSettings.Store.UpdateRepositoryOwner) 
-                    ? _updateCheckSettings.Store.UpdateRepositoryOwner 
-                    : AppIdentity.RepositoryOwner;
-                var repositoryName = !string.IsNullOrWhiteSpace(_updateCheckSettings.Store.UpdateRepositoryName) 
-                    ? _updateCheckSettings.Store.UpdateRepositoryName 
-                    : AppIdentity.RepositoryName;
+                var repositoryOwner = AppIdentity.RepositoryOwner;
+                var repositoryName = AppIdentity.RepositoryName;
+
+                if (!string.IsNullOrWhiteSpace(_updateCheckSettings.Store.UpdateRepositoryOwner) ||
+                    !string.IsNullOrWhiteSpace(_updateCheckSettings.Store.UpdateRepositoryName))
+                {
+                    var requestedOwner = _updateCheckSettings.Store.UpdateRepositoryOwner ?? AppIdentity.RepositoryOwner;
+                    var requestedName = _updateCheckSettings.Store.UpdateRepositoryName ?? AppIdentity.RepositoryName;
+
+                    if (!IsAllowedUpdateRepository(requestedOwner, requestedName))
+                    {
+                        Log.Instance.Warning($"Ignoring untrusted update repository override: {requestedOwner}/{requestedName}");
+                    }
+                    else
+                    {
+                        repositoryOwner = requestedOwner;
+                        repositoryName = requestedName;
+                    }
+                }
                 
                 if (Log.Instance.IsTraceEnabled)
                     Log.Instance.Trace($"Checking updates from repository: {repositoryOwner}/{repositoryName}");
@@ -221,15 +238,10 @@ public class UpdateChecker
 
         var expectedHash = await ResolveExpectedHashAsync(update, httpClient, cancellationToken).ConfigureAwait(false);
 
-        // If no expected hash is available, skip validation (backward compatibility)
         if (string.IsNullOrEmpty(expectedHash))
         {
-            if (Log.Instance.IsTraceEnabled)
-                Log.Instance.Trace($"No SHA256 hash available for validation. Skipping integrity check.");
-
-            // Log warning but don't block the update
-            Log.Instance.Warning($"Update package integrity verification skipped: no SHA256 hash available for update {update.Version}");
-            return;
+            TryDeleteFile(filePath);
+            throw new InvalidDataException($"Update package integrity check failed: no SHA256 hash is available for update {update.Version}.");
         }
 
         // Compare hashes
@@ -240,12 +252,7 @@ public class UpdateChecker
             if (Log.Instance.IsTraceEnabled)
                 Log.Instance.Trace(errorMessage);
 
-            // Delete the corrupted file
-            try
-            {
-                File.Delete(filePath);
-            }
-            catch { /* Ignore deletion errors */ }
+            TryDeleteFile(filePath);
 
             throw new InvalidDataException(errorMessage);
         }
@@ -384,6 +391,23 @@ public class UpdateChecker
 
         return Uri.TryCreate(value, UriKind.Absolute, out var uri) &&
                (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps);
+    }
+
+    private static bool IsAllowedUpdateRepository(string owner, string name) =>
+        AllowedUpdateRepositories.Any(repository =>
+            repository.Owner.Equals(owner, StringComparison.OrdinalIgnoreCase) &&
+            repository.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+
+    private static void TryDeleteFile(string filePath)
+    {
+        try
+        {
+            File.Delete(filePath);
+        }
+        catch
+        {
+            // Best-effort cleanup after a failed integrity check.
+        }
     }
 
     private static string[] GetPackageFileNameCandidates(string? packageUrl)

--- a/UniversalDeviceToolkit.Tests/Plugins/PluginPathsTests.cs
+++ b/UniversalDeviceToolkit.Tests/Plugins/PluginPathsTests.cs
@@ -12,16 +12,29 @@ namespace UniversalDeviceToolkit.Tests.Plugins;
 public class PluginPathsTests : TemporaryFileTestBase
 {
     private readonly string? _previousAppDataOverride;
+    private readonly string? _previousPluginsDirectoryOverride;
+    private readonly string? _previousLegacyPluginsDirectoryOverride;
+    private readonly string? _previousLegacyPluginConfigRoot;
 
     public PluginPathsTests()
     {
         _previousAppDataOverride = Environment.GetEnvironmentVariable(Folders.AppDataOverrideEnvironmentVariable);
+        _previousPluginsDirectoryOverride = Environment.GetEnvironmentVariable(PluginPaths.PluginsDirectoryOverrideEnvironmentVariable);
+        _previousLegacyPluginsDirectoryOverride = Environment.GetEnvironmentVariable(PluginPaths.LegacyPluginsDirectoryOverrideEnvironmentVariable);
+        _previousLegacyPluginConfigRoot = Environment.GetEnvironmentVariable(PluginPaths.LegacyPluginConfigRootEnvironmentVariable);
+
+        Environment.SetEnvironmentVariable(PluginPaths.PluginsDirectoryOverrideEnvironmentVariable, null);
+        Environment.SetEnvironmentVariable(PluginPaths.LegacyPluginsDirectoryOverrideEnvironmentVariable, null);
+        Environment.SetEnvironmentVariable(PluginPaths.LegacyPluginConfigRootEnvironmentVariable, null);
         Environment.SetEnvironmentVariable(Folders.AppDataOverrideEnvironmentVariable, CreateTempDirectory());
     }
 
     public override void Dispose()
     {
         Environment.SetEnvironmentVariable(Folders.AppDataOverrideEnvironmentVariable, _previousAppDataOverride);
+        Environment.SetEnvironmentVariable(PluginPaths.PluginsDirectoryOverrideEnvironmentVariable, _previousPluginsDirectoryOverride);
+        Environment.SetEnvironmentVariable(PluginPaths.LegacyPluginsDirectoryOverrideEnvironmentVariable, _previousLegacyPluginsDirectoryOverride);
+        Environment.SetEnvironmentVariable(PluginPaths.LegacyPluginConfigRootEnvironmentVariable, _previousLegacyPluginConfigRoot);
         base.Dispose();
     }
 
@@ -45,6 +58,38 @@ public class PluginPathsTests : TemporaryFileTestBase
         var pluginDir = PluginPaths.GetPluginDirectory("custom-mouse");
 
         pluginDir.Should().Be(Path.Combine(pluginsRoot, "custom-mouse"));
+    }
+
+    [Fact]
+    public void GetPluginsDirectory_WhenCanonicalOverrideSet_ShouldReturnOverride()
+    {
+        var overrideDirectory = Path.Combine(CreateTempDirectory(), "custom-plugins");
+        Environment.SetEnvironmentVariable(PluginPaths.PluginsDirectoryOverrideEnvironmentVariable, overrideDirectory);
+
+        var result = PluginPaths.GetPluginsDirectory();
+
+        result.Should().Be(Path.GetFullPath(overrideDirectory));
+        Directory.Exists(result).Should().BeTrue();
+    }
+
+    [Fact]
+    public void GetPluginsDirectory_WhenLegacyOverrideSet_ShouldReturnLegacyOverride()
+    {
+        var overrideDirectory = Path.Combine(CreateTempDirectory(), "legacy-plugins");
+        Environment.SetEnvironmentVariable(PluginPaths.LegacyPluginsDirectoryOverrideEnvironmentVariable, overrideDirectory);
+
+        PluginPaths.GetPluginsDirectory().Should().Be(Path.GetFullPath(overrideDirectory));
+    }
+
+    [Fact]
+    public void GetPluginsDirectory_WhenMultipleOverridesSet_ShouldPreferCanonicalOverride()
+    {
+        var canonicalDirectory = Path.Combine(CreateTempDirectory(), "canonical-plugins");
+        var legacyDirectory = Path.Combine(CreateTempDirectory(), "legacy-plugins");
+        Environment.SetEnvironmentVariable(PluginPaths.PluginsDirectoryOverrideEnvironmentVariable, canonicalDirectory);
+        Environment.SetEnvironmentVariable(PluginPaths.LegacyPluginsDirectoryOverrideEnvironmentVariable, legacyDirectory);
+
+        PluginPaths.GetPluginsDirectory().Should().Be(Path.GetFullPath(canonicalDirectory));
     }
 
     [Fact]

--- a/UniversalDeviceToolkit.Tests/Plugins/PluginRepositoryServiceTests.cs
+++ b/UniversalDeviceToolkit.Tests/Plugins/PluginRepositoryServiceTests.cs
@@ -458,6 +458,9 @@ public class PluginRepositoryServiceTests : TemporaryFileTestBase
 
     private string CreatePluginPackage(string pluginId, bool includeOptimizationAction)
     {
+        var appPluginsDirectory = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "plugins");
+        Directory.CreateDirectory(appPluginsDirectory);
+
         var packageDirectory = CreateTempDirectory();
         var pluginDirectory = Path.Combine(packageDirectory, pluginId);
         Directory.CreateDirectory(pluginDirectory);
@@ -467,7 +470,10 @@ public class PluginRepositoryServiceTests : TemporaryFileTestBase
             Path.Combine(pluginDirectory, "plugin.json"),
             CreateManifestJson(pluginId, includeOptimizationAction));
 
-        var packagePath = Path.Combine(packageDirectory, $"{pluginId}.zip");
+        var packagePath = Path.Combine(appPluginsDirectory, $"{pluginId}.zip");
+        if (File.Exists(packagePath))
+            File.Delete(packagePath);
+
         ZipFile.CreateFromDirectory(pluginDirectory, packagePath);
         TempFiles.Add(packagePath);
         return packagePath;

--- a/UniversalDeviceToolkit.Tests/Utils/UpdateCheckerTests.cs
+++ b/UniversalDeviceToolkit.Tests/Utils/UpdateCheckerTests.cs
@@ -191,7 +191,7 @@ public class UpdateCheckerTests : TemporaryFileTestBase
     }
 
     [Fact]
-    public async Task ValidateUpdatePackageAsync_WhenNoHashIsAvailable_ShouldSkipValidation()
+    public async Task ValidateUpdatePackageAsync_WhenNoHashIsAvailable_ShouldDeleteFileAndThrow()
     {
         // Arrange
         const string packageUrl = "https://example.com/LenovoLegionToolkitSetup.exe";
@@ -205,10 +205,11 @@ public class UpdateCheckerTests : TemporaryFileTestBase
         using var httpClient = new HttpClient(new StubHttpMessageHandler(_ => throw new InvalidOperationException("unexpected request")));
 
         // Act
-        await InvokeValidateUpdatePackageAsync(tempFile, update, httpClient);
+        var action = () => InvokeValidateUpdatePackageAsync(tempFile, update, httpClient);
 
         // Assert
-        File.Exists(tempFile).Should().BeTrue();
+        await action.Should().ThrowAsync<InvalidDataException>();
+        File.Exists(tempFile).Should().BeFalse();
     }
 
     private static async Task InvokeValidateUpdatePackageAsync(string filePath, Update update, HttpClient httpClient)

--- a/UniversalDeviceToolkit.Tests/WPF/PluginExecutableResolverTests.cs
+++ b/UniversalDeviceToolkit.Tests/WPF/PluginExecutableResolverTests.cs
@@ -1,7 +1,11 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Reflection;
+using System.Threading.Tasks;
 using FluentAssertions;
+using LenovoLegionToolkit.Lib.Plugins;
+using Moq;
 using Xunit;
 
 namespace UniversalDeviceToolkit.Tests.WPF;
@@ -182,10 +186,36 @@ public class PluginExecutableResolverTests : IDisposable
 
         method.Should().NotBeNull();
 
-        object?[] parameters = [pluginId, metadataFilePath, pluginsDirectory, null, null];
+        var signatureValidator = CreateSignatureValidator(pluginId);
+        object?[] parameters = [pluginId, metadataFilePath, pluginsDirectory, signatureValidator, null, null];
         var result = method!.Invoke(null, parameters);
 
         result.Should().BeOfType<bool>();
-        return ((bool)result!, parameters[3] as string, parameters[4] as string);
+        return ((bool)result!, parameters[4] as string, parameters[5] as string);
+    }
+
+    private static IPluginSignatureValidator CreateSignatureValidator(string pluginId)
+    {
+        var normalizedPluginId = pluginId.Replace("-", string.Empty);
+        var trustedExecutableNames = new[]
+        {
+            $"{pluginId}.exe",
+            $"LenovoLegionToolkit.Plugins.{pluginId}.exe",
+            $"LenovoLegionToolkit.Plugins.{normalizedPluginId}.exe"
+        };
+
+        var mock = new Mock<IPluginSignatureValidator>();
+        mock.Setup(validator => validator.ValidateAsync(It.IsAny<string>()))
+            .Returns((string executablePath) =>
+            {
+                var fileName = Path.GetFileName(executablePath);
+                var isTrusted = trustedExecutableNames.Any(name =>
+                    name.Equals(fileName, StringComparison.OrdinalIgnoreCase));
+
+                return Task.FromResult(new PluginSignatureResult(
+                    isTrusted ? PluginSignatureStatus.Valid : PluginSignatureStatus.Invalid));
+            });
+
+        return mock.Object;
     }
 }

--- a/UniversalDeviceToolkit.WPF/Pages/PluginExtensionsPage.xaml.cs
+++ b/UniversalDeviceToolkit.WPF/Pages/PluginExtensionsPage.xaml.cs
@@ -34,6 +34,7 @@ public partial class PluginExtensionsPage
 {
     private readonly ApplicationSettings _applicationSettings = IoCContainer.Resolve<ApplicationSettings>();
     private readonly IPluginManager _pluginManager = IoCContainer.Resolve<IPluginManager>();
+    private readonly IPluginSignatureValidator _pluginSignatureValidator = IoCContainer.Resolve<IPluginSignatureValidator>();
     private readonly PluginRepositoryService _pluginRepositoryService = IoCContainer.Resolve<PluginRepositoryService>();
     private readonly PluginInstallCoordinator _pluginInstallCoordinator = IoCContainer.Resolve<PluginInstallCoordinator>();
 
@@ -2355,7 +2356,7 @@ private string _currentSearchText = string.Empty;
     private bool TryResolvePluginExecutable(string pluginId, out string? exeFile, out string? workingDirectory)
     {
         var metadata = _pluginManager.GetPluginMetadata(pluginId);
-        return PluginExecutableResolver.TryResolve(pluginId, metadata?.FilePath, GetPluginsDirectory(), out exeFile, out workingDirectory);
+        return PluginExecutableResolver.TryResolve(pluginId, metadata?.FilePath, GetPluginsDirectory(), _pluginSignatureValidator, out exeFile, out workingDirectory);
     }
 
     private string GetPluginLocalizedName(IPlugin plugin, PluginManifest? manifest)

--- a/UniversalDeviceToolkit.WPF/Utils/PluginExecutableResolver.cs
+++ b/UniversalDeviceToolkit.WPF/Utils/PluginExecutableResolver.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using LenovoLegionToolkit.Lib.Plugins;
+using LenovoLegionToolkit.Lib.Utils;
 
 namespace UniversalDeviceToolkit.WPF.Utils;
 
@@ -11,6 +13,7 @@ internal static class PluginExecutableResolver
         string pluginId,
         string? metadataFilePath,
         string pluginsDirectory,
+        IPluginSignatureValidator signatureValidator,
         out string? exeFile,
         out string? workingDirectory)
     {
@@ -19,6 +22,7 @@ internal static class PluginExecutableResolver
 
         ArgumentException.ThrowIfNullOrWhiteSpace(pluginId);
         ArgumentException.ThrowIfNullOrWhiteSpace(pluginsDirectory);
+        ArgumentNullException.ThrowIfNull(signatureValidator);
 
         var candidateDirectories = new List<string>();
 
@@ -46,6 +50,9 @@ internal static class PluginExecutableResolver
                 if (!File.Exists(preferredCandidate))
                     continue;
 
+                if (!IsTrustedExecutable(preferredCandidate, signatureValidator))
+                    continue;
+
                 exeFile = preferredCandidate;
                 workingDirectory = candidateDirectory;
                 return true;
@@ -60,5 +67,17 @@ internal static class PluginExecutableResolver
         yield return Path.Combine(candidateDirectory, $"{pluginId}.exe");
         yield return Path.Combine(candidateDirectory, $"LenovoLegionToolkit.Plugins.{pluginId}.exe");
         yield return Path.Combine(candidateDirectory, $"LenovoLegionToolkit.Plugins.{pluginId.Replace("-", string.Empty)}.exe");
+    }
+
+    private static bool IsTrustedExecutable(string executablePath, IPluginSignatureValidator signatureValidator)
+    {
+        var signatureResult = signatureValidator.ValidateAsync(executablePath).GetAwaiter().GetResult();
+        if (signatureResult.IsValid)
+            return true;
+
+        if (Log.Instance.IsTraceEnabled)
+            Log.Instance.Trace($"Rejected plugin executable due to invalid signature. [path={executablePath}, status={signatureResult.Status}, error={signatureResult.ErrorMessage}]");
+
+        return false;
     }
 }


### PR DESCRIPTION
## Summary
- HMAC-protect `trusted-plugin-packages.json` (#58)
- Require official repo allowlist and SHA256 for updates (#61)
- Validate plugin EXE signatures before launch (#62)
- Implement plugin store update detection (#69)
- Share UDT WPF assemblies in PluginLoader (#59)
- Unify plugin directory env vars via `UDT_PLUGINS_DIR` (#46)

## Test plan
- [x] Plugin and update checker unit tests pass
- [ ] Install plugin from official store
- [ ] Verify unsigned plugin EXE is blocked

Closes #58, #61, #62, #69, #59, #46


Made with [Cursor](https://cursor.com)