### PR TITLE
test(custom-mouse): restore PluginSettingsFileSnapshot for CI

### DIFF
--- a/Plugins/Official/CustomMouse.Tests/CustomMousePluginTests.cs
+++ b/Plugins/Official/CustomMouse.Tests/CustomMousePluginTests.cs
@@ -1,3 +1,4 @@
+using UniversalDeviceToolkit.Lib.Utils;
 using UniversalDeviceToolkit.Plugins.CustomMouse;
 using UniversalDeviceToolkit.Plugins.SDK;
 using Microsoft.Win32;
@@ -470,6 +471,58 @@ public class CustomMousePluginTests
             cursorKey.SetValue(string.Empty, originalDefault ?? string.Empty);
             cursorKey.SetValue("Arrow", originalArrow ?? string.Empty);
         }
+    }
+}
+
+internal sealed class PluginSettingsFileSnapshot : IDisposable
+{
+    public static string SettingsFilePath =>
+        Path.Combine(Folders.GetAppDataSubdirectory("plugin-config"), "custom-mouse.json");
+
+    private readonly bool _existed;
+    private readonly string? _originalContent;
+
+    private PluginSettingsFileSnapshot(bool existed, string? originalContent)
+    {
+        _existed = existed;
+        _originalContent = originalContent;
+    }
+
+    public static PluginSettingsFileSnapshot Capture()
+    {
+        var path = SettingsFilePath;
+        if (!File.Exists(path))
+        {
+            return new PluginSettingsFileSnapshot(false, null);
+        }
+
+        return new PluginSettingsFileSnapshot(true, File.ReadAllText(path));
+    }
+
+    public void Restore()
+    {
+        var path = SettingsFilePath;
+        if (_existed)
+        {
+            var directory = Path.GetDirectoryName(path);
+            if (!string.IsNullOrEmpty(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            File.WriteAllText(path, _originalContent ?? string.Empty);
+            return;
+        }
+
+        if (File.Exists(path))
+        {
+            File.Delete(path);
+        }
+    }
+
+    public void Dispose()
+    {
+        Restore();
     }
 }
 

--- a/UniversalDeviceToolkit.Tests/Utils/ThrottleLastDispatcherTests.cs
+++ b/UniversalDeviceToolkit.Tests/Utils/ThrottleLastDispatcherTests.cs
@@ -156,20 +156,22 @@ public class ThrottleLastDispatcherTests
         var dispatcher = new ThrottleLastDispatcher(TimeSpan.FromMilliseconds(100));
         var executionOrder = new System.Collections.Generic.List<int>();
 
-        // Act
+        // Act: keep a handle to the last dispatch and await it so a loaded CI
+        // runner cannot finish the wall-clock sleep before the winning callback.
+        Task? last = null;
         for (int i = 0; i < 5; i++)
         {
             var value = i;
-            _ = dispatcher.DispatchAsync(async () =>
+            last = dispatcher.DispatchAsync(async () =>
             {
                 await Task.Delay(50);
                 executionOrder.Add(value);
             });
-            await Task.Delay(10);
+            if (i < 4)
+                await Task.Delay(10);
         }
 
-        // Wait for completion
-        await Task.Delay(200);
+        await last!;
 
         // Assert - Only the last call should have executed
         executionOrder.Should().ContainSingle().Which.Should().Be(4);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Adds the missing `PluginSettingsFileSnapshot` helper in CustomMouse tests so `master` (and merge CI on other PRs) compiles again (`CS0103` / `CS1503`).
- Makes `DispatchAsync_RapidCalls_ShouldCancelPreviousCalls` wait on the winning dispatch instead of a 200ms wall-clock sleep, matching the neighboring test that already called out this flake.

## Verification
- [ ] `dotnet build UniversalDeviceToolkit.sln --configuration Release`
- [ ] `dotnet test UniversalDeviceToolkit.Tests/UniversalDeviceToolkit.Tests.csproj --framework net10.0-windows`
- [ ] CHANGELOG.md updated for user-visible changes (skipped — test-only)

## Plugin Changes (if applicable)
- [ ] Plugin tests and validation pass (`Plugins\udt-plugin.cmd test` / `validate`)
- [ ] Official plugin metadata is in `Plugins/Official/*/plugin.manifest.json` (unchanged)
- [ ] Generated `Plugins/.build/catalog/store.json` was regenerated intentionally for a release (no)
- [ ] New plugin packages do not bundle host DLLs

## Notes
- Unblocks Build on `master` and inherited-red draft PRs (#181, #182). Does not change product behavior.
- Dependabot PRs #177–#180 still need rebase after this lands; #177 and #180 are major bumps and should not ride along.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed50ebbe-b5f4-4422-ae55-6fbd2d616fe9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed50ebbe-b5f4-4422-ae55-6fbd2d616fe9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

