### PR TITLE
fix(electron): keep Linux window chrome opaque

### DIFF
--- a/UniversalDeviceToolkit.Electron/src/main/index.ts
+++ b/UniversalDeviceToolkit.Electron/src/main/index.ts
@@ -161,6 +161,27 @@ if (process.platform === 'win32') {
   nativeTheme.on('updated', reapplyMainWindowBackgroundMaterial)
 }
 
+/** Opaque Linux stand-in for WindowBackdrop.css --udt-mica-chrome (light). */
+const LINUX_MICA_CHROME_LIGHT = '#d5ded5'
+const LINUX_WINDOW_BACKGROUND_DARK = '#202020'
+
+function linuxWindowBackgroundColor(): string {
+  return nativeTheme.shouldUseDarkColors ? LINUX_WINDOW_BACKGROUND_DARK : LINUX_MICA_CHROME_LIGHT
+}
+
+function applyLinuxWindowBackgroundColor(): void {
+  if (process.platform !== 'linux' || !mainWindow || mainWindow.isDestroyed()) return
+  try {
+    mainWindow.setBackgroundColor(linuxWindowBackgroundColor())
+  } catch (error) {
+    console.error('[main] failed to apply Linux window background:', error)
+  }
+}
+
+if (process.platform === 'linux') {
+  nativeTheme.on('updated', applyLinuxWindowBackgroundColor)
+}
+
 function resolveHostPath(): string {
   const fromEnv = process.env['UDT_HOST_PATH']
   if (fromEnv) {
@@ -722,12 +743,12 @@ function createWindow(): void {
         ? {
             // Linux: frameless custom title bar like Windows. backgroundMaterial
             // (mica/acrylic) is a Windows-only API — Electron ignores it on
-            // Linux, so an opaque window background keeps the load flash from
-            // being jarring (matches the renderer's --udt-surface-window #202020).
+            // Linux. Match the renderer: dark #202020, light mica-approx chrome
+            // (WindowBackdrop.css --udt-mica-chrome ≈ #d5ded5).
             autoHideMenuBar: true,
             frame: false,
-            backgroundColor: '#202020',
-            backgroundMaterial: 'acrylic' as const
+            backgroundColor: linuxWindowBackgroundColor(),
+            backgroundMaterial: 'none' as const
           }
         : {
             autoHideMenuBar: true,
@@ -1009,6 +1030,7 @@ app.whenReady().then(() => {
   ipcMain.on('window:set-theme-source', (_event, source: unknown) => {
     if (source !== 'system' && source !== 'light' && source !== 'dark') return
     nativeTheme.themeSource = source
+    applyLinuxWindowBackgroundColor()
   })
 
   ipcMain.handle('shell:open-log-folder', async () => {

--- a/UniversalDeviceToolkit.Electron/src/renderer/src/components/settings/WindowBackdropSetting.tsx
+++ b/UniversalDeviceToolkit.Electron/src/renderer/src/components/settings/WindowBackdropSetting.tsx
@@ -15,9 +15,9 @@ interface WindowBackdropSettingProps {
 
 const PLATFORM: string = window.bridge?.platform ?? 'win32'
 
-/** Options meaningful on the current platform (mica is Windows-only). */
+/** Options meaningful on the current platform (mica/acrylic are not native on Linux). */
 const OPTIONS: WindowBackdropStyle[] =
-  PLATFORM === 'win32' ? ['Windows', 'macOS', 'Off'] : ['macOS', 'Off']
+  PLATFORM === 'win32' ? ['Windows', 'macOS', 'Off'] : PLATFORM === 'linux' ? ['Off'] : ['macOS', 'Off']
 
 export default function WindowBackdropSetting({
   application,
@@ -31,7 +31,7 @@ export default function WindowBackdropSetting({
     Off: t('wpf.settingsPagewindowBackdropoff')
   }
   const rawStyle = normalizeWindowBackdropStyle(application['WindowBackdropStyle'])
-  const style: WindowBackdropStyle = OPTIONS.includes(rawStyle) ? rawStyle : 'macOS'
+  const style: WindowBackdropStyle = OPTIONS.includes(rawStyle) ? rawStyle : OPTIONS[0]
 
   return (
     <SettingsCard

--- a/UniversalDeviceToolkit.Electron/src/renderer/src/components/settings/WindowBackdropSetting.tsx
+++ b/UniversalDeviceToolkit.Electron/src/renderer/src/components/settings/WindowBackdropSetting.tsx
@@ -15,9 +15,9 @@ interface WindowBackdropSettingProps {
 
 const PLATFORM: string = window.bridge?.platform ?? 'win32'
 
-/** Options meaningful on the current platform (mica/acrylic are not native on Linux). */
+/** Native mica is Windows-only; Linux still offers Windows/macOS as opaque approximations. */
 const OPTIONS: WindowBackdropStyle[] =
-  PLATFORM === 'win32' ? ['Windows', 'macOS', 'Off'] : PLATFORM === 'linux' ? ['Off'] : ['macOS', 'Off']
+  PLATFORM === 'darwin' ? ['macOS', 'Off'] : ['Windows', 'macOS', 'Off']
 
 export default function WindowBackdropSetting({
   application,

--- a/UniversalDeviceToolkit.Electron/src/renderer/src/theme/WindowBackdrop.css
+++ b/UniversalDeviceToolkit.Electron/src/renderer/src/theme/WindowBackdrop.css
@@ -2,73 +2,75 @@
    Window Backdrop (Mica / Acrylic / Vibrancy) System
    ========================================================================== */
 
-/* ── Base Transparency when a native backdrop is active ── */
-:root[data-backdrop='mica'],
-:root[data-backdrop='acrylic'] {
+/* ── Base Transparency when a native backdrop is active ──
+   Linux has no DWM mica/acrylic; never punch chrome transparent there
+   (opaque #202020 window + light 跟随系统 = mixed dark shell / white cards). */
+:root[data-backdrop='mica']:not([data-platform='linux']),
+:root[data-backdrop='acrylic']:not([data-platform='linux']) {
   background: transparent !important;
 }
 
-:root[data-backdrop='mica'] body,
-:root[data-backdrop='mica'] #root,
-:root[data-backdrop='acrylic'] body,
-:root[data-backdrop='acrylic'] #root {
+:root[data-backdrop='mica']:not([data-platform='linux']) body,
+:root[data-backdrop='mica']:not([data-platform='linux']) #root,
+:root[data-backdrop='acrylic']:not([data-platform='linux']) body,
+:root[data-backdrop='acrylic']:not([data-platform='linux']) #root {
   background: transparent !important;
 }
 
 /* App shell container is transparent with subtle tint for contrast */
-:root[data-backdrop='mica'] .udt-app-shell,
-:root[data-backdrop='acrylic'] .udt-app-shell {
+:root[data-backdrop='mica']:not([data-platform='linux']) .udt-app-shell,
+:root[data-backdrop='acrylic']:not([data-platform='linux']) .udt-app-shell {
   background: transparent !important;
 }
 
-:root[data-backdrop='mica'] .udt-app-shell__body,
-:root[data-backdrop='acrylic'] .udt-app-shell__body {
+:root[data-backdrop='mica']:not([data-platform='linux']) .udt-app-shell__body,
+:root[data-backdrop='acrylic']:not([data-platform='linux']) .udt-app-shell__body {
   background: transparent !important;
 }
 
-:root[data-backdrop='mica'] .udt-titlebar,
-:root[data-backdrop='acrylic'] .udt-titlebar {
+:root[data-backdrop='mica']:not([data-platform='linux']) .udt-titlebar,
+:root[data-backdrop='acrylic']:not([data-platform='linux']) .udt-titlebar {
   background: transparent !important;
 }
 
-:root[data-backdrop='mica'] .udt-nav,
-:root[data-backdrop='acrylic'] .udt-nav {
+:root[data-backdrop='mica']:not([data-platform='linux']) .udt-nav,
+:root[data-backdrop='acrylic']:not([data-platform='linux']) .udt-nav {
   background: transparent !important;
 }
 
-:root[data-backdrop='mica'] .udt-app-shell__main,
-:root[data-backdrop='acrylic'] .udt-app-shell__main {
+:root[data-backdrop='mica']:not([data-platform='linux']) .udt-app-shell__main,
+:root[data-backdrop='acrylic']:not([data-platform='linux']) .udt-app-shell__main {
   background: transparent !important;
 }
 
 /* ── Mica Effect (Layered subtle translucent surface over wallpaper) ── */
-:root[data-backdrop='mica'] .udt-app-shell__content {
+:root[data-backdrop='mica']:not([data-platform='linux']) .udt-app-shell__content {
   background: rgba(27, 27, 27, 0.45);
   border-color: rgba(255, 255, 255, 0.08);
 }
 
-:root[data-theme='light'][data-backdrop='mica'] .udt-app-shell__content {
+:root[data-theme='light'][data-backdrop='mica']:not([data-platform='linux']) .udt-app-shell__content {
   background: rgba(255, 255, 255, 0.55);
   border-color: rgba(0, 0, 0, 0.08);
 }
 
 /* Mica cards have clean translucent surfaces with subtle glass backdrop */
-:root[data-backdrop='mica'] .udt-parity-card,
-:root[data-backdrop='mica'] .udt-sensor-board,
-:root[data-backdrop='mica'] .udt-card-base,
-:root[data-backdrop='mica'] .udt-settings-card,
-:root[data-backdrop='mica'] .udt-backdrop-setting {
+:root[data-backdrop='mica']:not([data-platform='linux']) .udt-parity-card,
+:root[data-backdrop='mica']:not([data-platform='linux']) .udt-sensor-board,
+:root[data-backdrop='mica']:not([data-platform='linux']) .udt-card-base,
+:root[data-backdrop='mica']:not([data-platform='linux']) .udt-settings-card,
+:root[data-backdrop='mica']:not([data-platform='linux']) .udt-backdrop-setting {
   background: rgba(38, 38, 38, 0.72) !important;
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
   border-color: rgba(255, 255, 255, 0.09) !important;
 }
 
-:root[data-theme='light'][data-backdrop='mica'] .udt-parity-card,
-:root[data-theme='light'][data-backdrop='mica'] .udt-sensor-board,
-:root[data-theme='light'][data-backdrop='mica'] .udt-card-base,
-:root[data-theme='light'][data-backdrop='mica'] .udt-settings-card,
-:root[data-theme='light'][data-backdrop='mica'] .udt-backdrop-setting {
+:root[data-theme='light'][data-backdrop='mica']:not([data-platform='linux']) .udt-parity-card,
+:root[data-theme='light'][data-backdrop='mica']:not([data-platform='linux']) .udt-sensor-board,
+:root[data-theme='light'][data-backdrop='mica']:not([data-platform='linux']) .udt-card-base,
+:root[data-theme='light'][data-backdrop='mica']:not([data-platform='linux']) .udt-settings-card,
+:root[data-theme='light'][data-backdrop='mica']:not([data-platform='linux']) .udt-backdrop-setting {
   background: rgba(255, 255, 255, 0.78) !important;
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
@@ -76,33 +78,33 @@
 }
 
 /* ── Acrylic Effect (Deep blurred translucent surface over windows) ── */
-:root[data-backdrop='acrylic'] .udt-app-shell__content {
+:root[data-backdrop='acrylic']:not([data-platform='linux']) .udt-app-shell__content {
   background: rgba(22, 22, 22, 0.35);
   border-color: rgba(255, 255, 255, 0.08);
 }
 
-:root[data-theme='light'][data-backdrop='acrylic'] .udt-app-shell__content {
+:root[data-theme='light'][data-backdrop='acrylic']:not([data-platform='linux']) .udt-app-shell__content {
   background: rgba(248, 248, 248, 0.45);
   border-color: rgba(0, 0, 0, 0.08);
 }
 
 /* Acrylic cards */
-:root[data-backdrop='acrylic'] .udt-parity-card,
-:root[data-backdrop='acrylic'] .udt-sensor-board,
-:root[data-backdrop='acrylic'] .udt-card-base,
-:root[data-backdrop='acrylic'] .udt-settings-card,
-:root[data-backdrop='acrylic'] .udt-backdrop-setting {
+:root[data-backdrop='acrylic']:not([data-platform='linux']) .udt-parity-card,
+:root[data-backdrop='acrylic']:not([data-platform='linux']) .udt-sensor-board,
+:root[data-backdrop='acrylic']:not([data-platform='linux']) .udt-card-base,
+:root[data-backdrop='acrylic']:not([data-platform='linux']) .udt-settings-card,
+:root[data-backdrop='acrylic']:not([data-platform='linux']) .udt-backdrop-setting {
   background: rgba(35, 35, 35, 0.65) !important;
   backdrop-filter: blur(16px);
   -webkit-backdrop-filter: blur(16px);
   border-color: rgba(255, 255, 255, 0.10) !important;
 }
 
-:root[data-theme='light'][data-backdrop='acrylic'] .udt-parity-card,
-:root[data-theme='light'][data-backdrop='acrylic'] .udt-sensor-board,
-:root[data-theme='light'][data-backdrop='acrylic'] .udt-card-base,
-:root[data-theme='light'][data-backdrop='acrylic'] .udt-settings-card,
-:root[data-theme='light'][data-backdrop='acrylic'] .udt-backdrop-setting {
+:root[data-theme='light'][data-backdrop='acrylic']:not([data-platform='linux']) .udt-parity-card,
+:root[data-theme='light'][data-backdrop='acrylic']:not([data-platform='linux']) .udt-sensor-board,
+:root[data-theme='light'][data-backdrop='acrylic']:not([data-platform='linux']) .udt-card-base,
+:root[data-theme='light'][data-backdrop='acrylic']:not([data-platform='linux']) .udt-settings-card,
+:root[data-theme='light'][data-backdrop='acrylic']:not([data-platform='linux']) .udt-backdrop-setting {
   background: rgba(255, 255, 255, 0.72) !important;
   backdrop-filter: blur(16px);
   -webkit-backdrop-filter: blur(16px);

--- a/UniversalDeviceToolkit.Electron/src/renderer/src/theme/WindowBackdrop.css
+++ b/UniversalDeviceToolkit.Electron/src/renderer/src/theme/WindowBackdrop.css
@@ -3,8 +3,8 @@
    ========================================================================== */
 
 /* ── Base Transparency when a native backdrop is active ──
-   Linux has no DWM mica/acrylic; never punch chrome transparent there
-   (opaque #202020 window + light 跟随系统 = mixed dark shell / white cards). */
+   Linux has no DWM mica/acrylic; never punch chrome transparent there.
+   Light Linux mica/acrylic uses the opaque stand-in further below. */
 :root[data-backdrop='mica']:not([data-platform='linux']),
 :root[data-backdrop='acrylic']:not([data-platform='linux']) {
   background: transparent !important;
@@ -109,6 +109,68 @@
   backdrop-filter: blur(16px);
   -webkit-backdrop-filter: blur(16px);
   border-color: rgba(0, 0, 0, 0.08) !important;
+}
+
+/* ── Linux opaque mica / acrylic stand-in ────────────────────────────
+   Electron has no DWM. Transparency is already skipped above; these
+   fills composite the same light-mica alphas from this file
+   (content 55% white, cards 78% white) over --udt-surface-navigation
+   (#f6f6f6) plus a Win11 bloom wallpaper sample so the sidebar/title
+   bar read as light green-gray instead of a dark #202020 flash.
+   Dark theme stays the existing opaque navigation/window tokens. */
+:root[data-theme='light'] {
+  --udt-mica-wallpaper-sample: #9bb39a;
+  --udt-mica-chrome: color-mix(in srgb, var(--udt-mica-wallpaper-sample) 36%, #f6f6f6);
+  --udt-mica-pane: color-mix(in srgb, #ffffff 55%, var(--udt-mica-chrome));
+  --udt-mica-card: color-mix(in srgb, #ffffff 78%, var(--udt-mica-chrome));
+}
+
+:root[data-theme='light'][data-platform='linux'][data-backdrop='mica'],
+:root[data-theme='light'][data-platform='linux'][data-backdrop='acrylic'] {
+  --udt-surface-navigation: var(--udt-mica-chrome);
+  background: var(--udt-mica-chrome) !important;
+}
+
+:root[data-platform='linux'][data-backdrop='mica'],
+:root[data-platform='linux'][data-backdrop='acrylic'] {
+  background: var(--udt-surface-navigation) !important;
+}
+
+:root[data-platform='linux'][data-backdrop='mica'] body,
+:root[data-platform='linux'][data-backdrop='mica'] #root,
+:root[data-platform='linux'][data-backdrop='mica'] .udt-app-shell,
+:root[data-platform='linux'][data-backdrop='acrylic'] body,
+:root[data-platform='linux'][data-backdrop='acrylic'] #root,
+:root[data-platform='linux'][data-backdrop='acrylic'] .udt-app-shell {
+  background: var(--udt-surface-navigation) !important;
+}
+
+:root[data-platform='linux'][data-backdrop='mica'] .udt-app-shell__content,
+:root[data-platform='linux'][data-backdrop='mica'] .udt-app-shell__main,
+:root[data-platform='linux'][data-backdrop='acrylic'] .udt-app-shell__content,
+:root[data-platform='linux'][data-backdrop='acrylic'] .udt-app-shell__main {
+  background: var(--udt-surface-window) !important;
+}
+
+:root[data-theme='light'][data-platform='linux'][data-backdrop='mica'] .udt-app-shell__content,
+:root[data-theme='light'][data-platform='linux'][data-backdrop='mica'] .udt-app-shell__main,
+:root[data-theme='light'][data-platform='linux'][data-backdrop='acrylic'] .udt-app-shell__content,
+:root[data-theme='light'][data-platform='linux'][data-backdrop='acrylic'] .udt-app-shell__main {
+  background: var(--udt-mica-pane) !important;
+}
+
+:root[data-theme='light'][data-platform='linux'][data-backdrop='mica'] .udt-parity-card,
+:root[data-theme='light'][data-platform='linux'][data-backdrop='mica'] .udt-sensor-board,
+:root[data-theme='light'][data-platform='linux'][data-backdrop='mica'] .udt-card-base,
+:root[data-theme='light'][data-platform='linux'][data-backdrop='mica'] .udt-settings-card,
+:root[data-theme='light'][data-platform='linux'][data-backdrop='mica'] .udt-backdrop-setting,
+:root[data-theme='light'][data-platform='linux'][data-backdrop='acrylic'] .udt-parity-card,
+:root[data-theme='light'][data-platform='linux'][data-backdrop='acrylic'] .udt-sensor-board,
+:root[data-theme='light'][data-platform='linux'][data-backdrop='acrylic'] .udt-card-base,
+:root[data-theme='light'][data-platform='linux'][data-backdrop='acrylic'] .udt-settings-card,
+:root[data-theme='light'][data-platform='linux'][data-backdrop='acrylic'] .udt-backdrop-setting {
+  background: var(--udt-mica-card) !important;
+  border-color: rgba(0, 0, 0, 0.07) !important;
 }
 
 /* Settings card styling for Backdrop Option row */

--- a/UniversalDeviceToolkit.Electron/src/renderer/src/theme/windowBackdrop.ts
+++ b/UniversalDeviceToolkit.Electron/src/renderer/src/theme/windowBackdrop.ts
@@ -31,6 +31,16 @@ export function applyWindowBackdrop(style: WindowBackdropStyle): void {
     return
   }
 
+  // Electron backgroundMaterial (mica/acrylic) is a Windows DWM API. On Linux
+  // the main window is an opaque #202020 surface (see createWindow); leaving
+  // data-backdrop=mica/acrylic punches chrome transparent so light 跟随系统
+  // paints white cards on a dark shell — the washed-out mixed theme.
+  if (CURRENT_PLATFORM === 'linux') {
+    document.documentElement.dataset.backdrop = 'none'
+    void window.bridge?.setBackgroundMaterial?.('none')
+    return
+  }
+
   const material = MATERIAL_BY_STYLE[style]
   document.documentElement.dataset.backdrop = material
   void window.bridge?.setBackgroundMaterial(material)

--- a/UniversalDeviceToolkit.Electron/src/renderer/src/theme/windowBackdrop.ts
+++ b/UniversalDeviceToolkit.Electron/src/renderer/src/theme/windowBackdrop.ts
@@ -10,38 +10,42 @@ const MATERIAL_BY_STYLE: Record<WindowBackdropStyle, BackgroundMaterial> = {
 }
 
 /** Bridge exposes the platform (win32 | darwin | linux). */
-const CURRENT_PLATFORM: string = window.bridge?.platform ?? 'win32'
+export function currentBackdropPlatform(): string {
+  return window.bridge?.platform ?? 'win32'
+}
 
 export function normalizeWindowBackdropStyle(value: unknown): WindowBackdropStyle {
   return value === 'macOS' || value === 'Off' ? value : 'Windows'
 }
 
 export function applyWindowBackdrop(style: WindowBackdropStyle): void {
+  const platform = currentBackdropPlatform()
   const canUseNativeMaterial =
     typeof window.bridge?.setBackgroundMaterial === 'function' &&
-    window.bridge.platform !== 'web'
+    platform !== 'web'
 
   if (!canUseNativeMaterial) {
     document.documentElement.dataset.backdrop = 'none'
     return
   }
 
-  if (CURRENT_PLATFORM === 'darwin') {
-    document.documentElement.dataset.backdrop = MATERIAL_BY_STYLE[style] === 'none' ? 'none' : 'acrylic'
+  const material = MATERIAL_BY_STYLE[style]
+
+  if (platform === 'darwin') {
+    document.documentElement.dataset.backdrop = material === 'none' ? 'none' : 'acrylic'
     return
   }
 
   // Electron backgroundMaterial (mica/acrylic) is a Windows DWM API. On Linux
-  // the main window is an opaque #202020 surface (see createWindow); leaving
-  // data-backdrop=mica/acrylic punches chrome transparent so light 跟随系统
-  // paints white cards on a dark shell — the washed-out mixed theme.
-  if (CURRENT_PLATFORM === 'linux') {
-    document.documentElement.dataset.backdrop = 'none'
+  // keep data-backdrop so CSS can paint an opaque mica/acrylic approximation
+  // (light sage chrome / dark #202020 fills). Never request a native material
+  // and never punch chrome transparent over the BrowserWindow color.
+  if (platform === 'linux') {
+    document.documentElement.dataset.backdrop = material
     void window.bridge?.setBackgroundMaterial?.('none')
     return
   }
 
-  const material = MATERIAL_BY_STYLE[style]
   document.documentElement.dataset.backdrop = material
   void window.bridge?.setBackgroundMaterial(material)
 }

--- a/UniversalDeviceToolkit.Electron/tests/windowBackdrop.test.mjs
+++ b/UniversalDeviceToolkit.Electron/tests/windowBackdrop.test.mjs
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import { URL } from 'node:url'
+import ts from 'typescript'
+
+const css = readFileSync(
+  new URL('../src/renderer/src/theme/WindowBackdrop.css', import.meta.url),
+  'utf8'
+)
+const backdropTs = readFileSync(
+  new URL('../src/renderer/src/theme/windowBackdrop.ts', import.meta.url),
+  'utf8'
+)
+const settingTs = readFileSync(
+  new URL('../src/renderer/src/components/settings/WindowBackdropSetting.tsx', import.meta.url),
+  'utf8'
+)
+const mainTs = readFileSync(new URL('../src/main/index.ts', import.meta.url), 'utf8')
+
+async function importBackdrop(platform) {
+  const materials = []
+  const root = { dataset: {} }
+  globalThis.window = {
+    bridge: {
+      platform,
+      setBackgroundMaterial: async (material) => {
+        materials.push(material)
+      }
+    }
+  }
+  globalThis.document = { documentElement: root }
+
+  const stripped = backdropTs.replace(
+    /import \{ settingsApi \} from '\.\.\/api\/settings'\r?\n/,
+    'const settingsApi = { get: async () => ({ value: null }) }\n'
+  )
+  const output = ts.transpileModule(stripped, {
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ES2022
+    }
+  }).outputText
+  const moduleUrl = `data:text/javascript;charset=utf-8,${encodeURIComponent(`${output}\n`)}`
+  const mod = await import(`${moduleUrl}#${platform}-${Date.now()}-${Math.random()}`)
+  return { mod, root, materials }
+}
+
+test('Linux mica/acrylic CSS stays opaque and paints a light mica stand-in', () => {
+  assert.match(css, /:not\(\[data-platform='linux'\]\)/)
+  assert.match(css, /--udt-mica-chrome:\s*color-mix/)
+  assert.match(css, /--udt-mica-wallpaper-sample:\s*#9bb39a/)
+  assert.match(css, /36%,\s*#f6f6f6/)
+  assert.match(css, /#ffffff 55%/)
+  assert.match(css, /#ffffff 78%/)
+  assert.match(
+    css,
+    /\[data-theme='light'\]\[data-platform='linux'\]\[data-backdrop='mica'\]/
+  )
+  assert.match(css, /--udt-surface-navigation:\s*var\(--udt-mica-chrome\)/)
+  assert.match(
+    css,
+    /\[data-platform='linux'\]\[data-backdrop='mica'\] \.udt-app-shell/
+  )
+  assert.match(css, /:not\(\[data-platform='linux'\]\) \.udt-nav/)
+  assert.doesNotMatch(
+    css,
+    /\[data-platform='linux'\]\[data-backdrop='(?:mica|acrylic)'\] \.udt-nav/
+  )
+})
+
+test('Linux settings still offer Windows mica as an opaque approximation', () => {
+  assert.match(settingTs, /PLATFORM === 'darwin' \? \['macOS', 'Off'\] : \['Windows', 'macOS', 'Off'\]/)
+  assert.doesNotMatch(settingTs, /PLATFORM === 'linux' \? \['Off'\]/)
+})
+
+test('Linux BrowserWindow uses theme-aware mica chrome, not a hardcoded #202020', () => {
+  assert.match(mainTs, /LINUX_MICA_CHROME_LIGHT = '#d5ded5'/)
+  assert.match(mainTs, /linuxWindowBackgroundColor\(\)/)
+  assert.match(mainTs, /applyLinuxWindowBackgroundColor\(\)/)
+  assert.doesNotMatch(
+    mainTs,
+    /process\.platform === 'linux'[\s\S]{0,400}backgroundColor: '#202020'/
+  )
+})
+
+test('applyWindowBackdrop keeps mica on Linux and requests no native material', async () => {
+  const { mod, root, materials } = await importBackdrop('linux')
+  mod.applyWindowBackdrop('Windows')
+  assert.equal(root.dataset.backdrop, 'mica')
+  assert.deepEqual(materials, ['none'])
+
+  mod.applyWindowBackdrop('macOS')
+  assert.equal(root.dataset.backdrop, 'acrylic')
+  assert.deepEqual(materials, ['none', 'none'])
+
+  mod.applyWindowBackdrop('Off')
+  assert.equal(root.dataset.backdrop, 'none')
+  assert.deepEqual(materials, ['none', 'none', 'none'])
+})
+
+test('applyWindowBackdrop still applies native mica on Windows', async () => {
+  const { mod, root, materials } = await importBackdrop('win32')
+  mod.applyWindowBackdrop('Windows')
+  assert.equal(root.dataset.backdrop, 'mica')
+  assert.deepEqual(materials, ['mica'])
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Linux cannot use DWM mica. Do not punch `.udt-nav` / `.udt-titlebar` transparent (that mixed a dark sidebar with white cards).
- Keep backdrop **opaque** on Linux, but light mica/acrylic now uses a sage stand-in (`color-mix` of `#9bb39a` over `#f6f6f6`) so 亮色 matches the Windows console (浅绿侧栏 + 白底) instead of `#202020`.
- Dark + mica stays opaque dark tokens. Settings still offer Windows / macOS / Off as opaque approximations.

## Verification
- [ ] `dotnet build UniversalDeviceToolkit.sln --configuration Release`
- [ ] `dotnet test UniversalDeviceToolkit.Tests/UniversalDeviceToolkit.Tests.csproj --framework net10.0-windows`
- [ ] CHANGELOG.md updated for user-visible changes (skipped — Linux renderer chrome only)

## Plugin Changes (if applicable)
- N/A

## Notes
- Recapture of the 6.0.0 promo (PR #182) is 亮色 控制台 with this chrome.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed50ebbe-b5f4-4422-ae55-6fbd2d616fe9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed50ebbe-b5f4-4422-ae55-6fbd2d616fe9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

