### PR TITLE
feat(installer): choose optional modules on install

### DIFF
--- a/UniversalDeviceToolkit.Electron/buildResources/installer.nsh
+++ b/UniversalDeviceToolkit.Electron/buildResources/installer.nsh
@@ -23,9 +23,21 @@
 Var udtSelectionInitialized
 Var udtLanguage
 Var udtDeviceMode
+Var udtFeatOpt
+Var udtFeatNet
+Var udtFeatAuto
+Var udtFeatMacro
+Var udtFeatKbd
+Var udtFeatPlug
 Var udtLanguageCombo
 Var udtAutoRadio
 Var udtBasicRadio
+Var udtFeatOptCheck
+Var udtFeatNetCheck
+Var udtFeatAutoCheck
+Var udtFeatMacroCheck
+Var udtFeatKbdCheck
+Var udtFeatPlugCheck
 Var udtPathEdit
 Var udtBrowseButton
 Var udtRequiredLabel
@@ -43,9 +55,33 @@ Function UdtLoadSelection
   ; existed. An existing valid selection is retained on an upgrade.
   StrCpy $udtLanguage "zh-CN"
   StrCpy $udtDeviceMode "auto"
+  StrCpy $udtFeatOpt "1"
+  StrCpy $udtFeatNet "1"
+  StrCpy $udtFeatAuto "1"
+  StrCpy $udtFeatMacro "1"
+  StrCpy $udtFeatKbd "1"
+  StrCpy $udtFeatPlug "1"
   IfFileExists "${UDT_SELECTION_FILE}" 0 udtSelectionValidate
     ReadINIStr $udtLanguage "${UDT_SELECTION_FILE}" "installation" "language"
     ReadINIStr $udtDeviceMode "${UDT_SELECTION_FILE}" "installation" "deviceMode"
+    ReadINIStr $0 "${UDT_SELECTION_FILE}" "installation" "windowsOptimization"
+    StrCmp $0 "0" 0 +2
+      StrCpy $udtFeatOpt "0"
+    ReadINIStr $0 "${UDT_SELECTION_FILE}" "installation" "networkAcceleration"
+    StrCmp $0 "0" 0 +2
+      StrCpy $udtFeatNet "0"
+    ReadINIStr $0 "${UDT_SELECTION_FILE}" "installation" "automation"
+    StrCmp $0 "0" 0 +2
+      StrCpy $udtFeatAuto "0"
+    ReadINIStr $0 "${UDT_SELECTION_FILE}" "installation" "macro"
+    StrCmp $0 "0" 0 +2
+      StrCpy $udtFeatMacro "0"
+    ReadINIStr $0 "${UDT_SELECTION_FILE}" "installation" "keyboard"
+    StrCmp $0 "0" 0 +2
+      StrCpy $udtFeatKbd "0"
+    ReadINIStr $0 "${UDT_SELECTION_FILE}" "installation" "pluginExtensions"
+    StrCmp $0 "0" 0 +2
+      StrCpy $udtFeatPlug "0"
 
   udtSelectionValidate:
   StrCmp $udtLanguage "en" udtLanguageValid
@@ -78,6 +114,9 @@ Function UdtLoadSelection
   StrCmp $udtDeviceMode "basic" udtDeviceModeValid
   StrCpy $udtDeviceMode "auto"
   udtDeviceModeValid:
+  ${If} $udtFeatOpt != "1"
+    StrCpy $udtFeatNet "0"
+  ${EndIf}
   StrCpy $udtSelectionInitialized "1"
 FunctionEnd
 
@@ -425,6 +464,156 @@ Function UdtDeviceLeave
   ${EndIf}
 FunctionEnd
 
+Function UdtApplyFeatureCheck
+  ${NSD_GetState} $udtFeatOptCheck $0
+  ${If} $0 == ${BST_CHECKED}
+    EnableWindow $udtFeatNetCheck 1
+  ${Else}
+    ${NSD_SetState} $udtFeatNetCheck ${BST_UNCHECKED}
+    EnableWindow $udtFeatNetCheck 0
+  ${EndIf}
+FunctionEnd
+
+Function UdtOptClicked
+  Pop $0
+  Call UdtApplyFeatureCheck
+FunctionEnd
+
+Function UdtFeaturesPage
+  Call UdtLoadSelection
+  Call UdtHideNativeChrome
+  Call UdtCreateFonts
+  nsDialogs::Create 1018
+  Pop $0
+  ${If} $0 == error
+    Abort
+  ${EndIf}
+  System::Call 'user32::SetWindowPos(i $0, i 0, i 0, i 0, i 750, i 500, i 0)'
+  SetCtlColors $0 "" "${UDT_BG}"
+  ${NSD_CreateLabel} 22u 12u 300u 24u "选择功能 / Choose features"
+  Pop $1
+  SetCtlColors $1 "${UDT_TEXT}" "transparent"
+  SendMessage $1 ${WM_SETFONT} $udtFontTitle 0
+  ${NSD_CreateLabel} 22u 38u 300u 18u "Required components stay installed. Optional modules can be omitted."
+  Pop $1
+  SetCtlColors $1 "${UDT_MUTED}" "transparent"
+
+  ${NSD_CreateLabel} 22u 62u 145u 14u "Required / 必选"
+  Pop $1
+  SetCtlColors $1 "${UDT_TEXT}" "transparent"
+  ${NSD_CreateCheckbox} 22u 80u 145u 14u "Host runtime"
+  Pop $1
+  ${NSD_SetState} $1 ${BST_CHECKED}
+  EnableWindow $1 0
+  SetCtlColors $1 "${UDT_TEXT}" "transparent"
+  ${NSD_CreateCheckbox} 22u 96u 145u 14u "Desktop shell"
+  Pop $1
+  ${NSD_SetState} $1 ${BST_CHECKED}
+  EnableWindow $1 0
+  SetCtlColors $1 "${UDT_TEXT}" "transparent"
+  ${NSD_CreateCheckbox} 22u 112u 145u 14u "Console / 控制台"
+  Pop $1
+  ${NSD_SetState} $1 ${BST_CHECKED}
+  EnableWindow $1 0
+  SetCtlColors $1 "${UDT_TEXT}" "transparent"
+  ${NSD_CreateCheckbox} 22u 128u 145u 14u "Settings / 设置"
+  Pop $1
+  ${NSD_SetState} $1 ${BST_CHECKED}
+  EnableWindow $1 0
+  SetCtlColors $1 "${UDT_TEXT}" "transparent"
+  ${NSD_CreateCheckbox} 22u 144u 145u 14u "About / 关于"
+  Pop $1
+  ${NSD_SetState} $1 ${BST_CHECKED}
+  EnableWindow $1 0
+  SetCtlColors $1 "${UDT_TEXT}" "transparent"
+
+  ${NSD_CreateLabel} 175u 62u 155u 14u "Optional / 可选"
+  Pop $1
+  SetCtlColors $1 "${UDT_TEXT}" "transparent"
+  ${NSD_CreateCheckbox} 175u 80u 155u 14u "System optimization"
+  Pop $udtFeatOptCheck
+  SetCtlColors $udtFeatOptCheck "${UDT_TEXT}" "transparent"
+  ${NSD_CreateCheckbox} 175u 96u 155u 14u "Network acceleration"
+  Pop $udtFeatNetCheck
+  SetCtlColors $udtFeatNetCheck "${UDT_TEXT}" "transparent"
+  ${NSD_CreateCheckbox} 175u 112u 155u 14u "Automation"
+  Pop $udtFeatAutoCheck
+  SetCtlColors $udtFeatAutoCheck "${UDT_TEXT}" "transparent"
+  ${NSD_CreateCheckbox} 175u 128u 155u 14u "Custom macro"
+  Pop $udtFeatMacroCheck
+  SetCtlColors $udtFeatMacroCheck "${UDT_TEXT}" "transparent"
+  ${NSD_CreateCheckbox} 175u 144u 155u 14u "Keyboard"
+  Pop $udtFeatKbdCheck
+  SetCtlColors $udtFeatKbdCheck "${UDT_TEXT}" "transparent"
+  ${NSD_CreateCheckbox} 175u 160u 155u 14u "Plugins & extensions"
+  Pop $udtFeatPlugCheck
+  SetCtlColors $udtFeatPlugCheck "${UDT_TEXT}" "transparent"
+
+  ${If} $udtFeatOpt == "1"
+    ${NSD_SetState} $udtFeatOptCheck ${BST_CHECKED}
+  ${EndIf}
+  ${If} $udtFeatNet == "1"
+    ${NSD_SetState} $udtFeatNetCheck ${BST_CHECKED}
+  ${EndIf}
+  ${If} $udtFeatAuto == "1"
+    ${NSD_SetState} $udtFeatAutoCheck ${BST_CHECKED}
+  ${EndIf}
+  ${If} $udtFeatMacro == "1"
+    ${NSD_SetState} $udtFeatMacroCheck ${BST_CHECKED}
+  ${EndIf}
+  ${If} $udtFeatKbd == "1"
+    ${NSD_SetState} $udtFeatKbdCheck ${BST_CHECKED}
+  ${EndIf}
+  ${If} $udtFeatPlug == "1"
+    ${NSD_SetState} $udtFeatPlugCheck ${BST_CHECKED}
+  ${EndIf}
+  ${NSD_OnClick} $udtFeatOptCheck UdtOptClicked
+  Call UdtApplyFeatureCheck
+  nsDialogs::Show
+FunctionEnd
+
+Function UdtFeaturesLeave
+  ${NSD_GetState} $udtFeatOptCheck $0
+  ${If} $0 == ${BST_CHECKED}
+    StrCpy $udtFeatOpt "1"
+  ${Else}
+    StrCpy $udtFeatOpt "0"
+  ${EndIf}
+  ${NSD_GetState} $udtFeatNetCheck $0
+  ${If} $0 == ${BST_CHECKED}
+    StrCpy $udtFeatNet "1"
+  ${Else}
+    StrCpy $udtFeatNet "0"
+  ${EndIf}
+  ${NSD_GetState} $udtFeatAutoCheck $0
+  ${If} $0 == ${BST_CHECKED}
+    StrCpy $udtFeatAuto "1"
+  ${Else}
+    StrCpy $udtFeatAuto "0"
+  ${EndIf}
+  ${NSD_GetState} $udtFeatMacroCheck $0
+  ${If} $0 == ${BST_CHECKED}
+    StrCpy $udtFeatMacro "1"
+  ${Else}
+    StrCpy $udtFeatMacro "0"
+  ${EndIf}
+  ${NSD_GetState} $udtFeatKbdCheck $0
+  ${If} $0 == ${BST_CHECKED}
+    StrCpy $udtFeatKbd "1"
+  ${Else}
+    StrCpy $udtFeatKbd "0"
+  ${EndIf}
+  ${NSD_GetState} $udtFeatPlugCheck $0
+  ${If} $0 == ${BST_CHECKED}
+    StrCpy $udtFeatPlug "1"
+  ${Else}
+    StrCpy $udtFeatPlug "0"
+  ${EndIf}
+  ${If} $udtFeatOpt != "1"
+    StrCpy $udtFeatNet "0"
+  ${EndIf}
+FunctionEnd
+
 ; Define the first page in place of the default white welcome page. The path
 ; selector lives inside the branded page, therefore the stock directory page
 ; is disabled in electron-builder.yml.
@@ -436,6 +625,7 @@ FunctionEnd
 !macro customPageAfterChangeDir
   Page custom UdtLanguagePage UdtLanguageLeave
   Page custom UdtDevicePage UdtDeviceLeave
+  Page custom UdtFeaturesPage UdtFeaturesLeave
 !macroend
 !endif
 
@@ -443,6 +633,19 @@ FunctionEnd
   Call UdtLoadSelection
   WriteINIStr "${UDT_SELECTION_FILE}" "installation" "language" "$udtLanguage"
   WriteINIStr "${UDT_SELECTION_FILE}" "installation" "deviceMode" "$udtDeviceMode"
+  WriteINIStr "${UDT_SELECTION_FILE}" "installation" "windowsOptimization" "$udtFeatOpt"
+  WriteINIStr "${UDT_SELECTION_FILE}" "installation" "networkAcceleration" "$udtFeatNet"
+  WriteINIStr "${UDT_SELECTION_FILE}" "installation" "automation" "$udtFeatAuto"
+  WriteINIStr "${UDT_SELECTION_FILE}" "installation" "macro" "$udtFeatMacro"
+  WriteINIStr "${UDT_SELECTION_FILE}" "installation" "keyboard" "$udtFeatKbd"
+  WriteINIStr "${UDT_SELECTION_FILE}" "installation" "pluginExtensions" "$udtFeatPlug"
+  ${If} $udtFeatNet != "1"
+    Delete "$INSTDIR\resources\host\UniversalDeviceToolkit.NetworkProxy.exe"
+    Delete "$INSTDIR\resources\host\UniversalDeviceToolkit.NetworkProxy.dll"
+    Delete "$INSTDIR\resources\host\UniversalDeviceToolkit.NetworkProxy.runtimeconfig.json"
+    Delete "$INSTDIR\resources\host\UniversalDeviceToolkit.NetworkProxy.deps.json"
+    Delete "$INSTDIR\resources\host\UniversalDeviceToolkit.NetworkProxy.pdb"
+  ${EndIf}
 !macroend
 
 !macro customUnInstall

--- a/UniversalDeviceToolkit.Electron/installer/features.mjs
+++ b/UniversalDeviceToolkit.Electron/installer/features.mjs
@@ -1,0 +1,39 @@
+/** Optional modules the custom installer can omit. Keep IDs aligned with src/shared/installer-selection.ts. */
+export const OPTIONAL_FEATURES = [
+  'windowsOptimization',
+  'networkAcceleration',
+  'automation',
+  'macro',
+  'keyboard',
+  'pluginExtensions'
+]
+
+export function defaultFeatures() {
+  return {
+    windowsOptimization: true,
+    networkAcceleration: true,
+    automation: true,
+    macro: true,
+    keyboard: true,
+    pluginExtensions: true
+  }
+}
+
+export function normalizeFeatures(raw) {
+  const features = defaultFeatures()
+  if (raw == null || typeof raw !== 'object') return features
+  for (const key of OPTIONAL_FEATURES) {
+    if (raw[key] === false || raw[key] === 0 || raw[key] === '0') features[key] = false
+  }
+  if (!features.windowsOptimization) features.networkAcceleration = false
+  return features
+}
+
+export function featureFlag(value) {
+  return value ? '1' : '0'
+}
+
+export function isNetworkProxySidecarFile(relativePath) {
+  const name = String(relativePath).replaceAll('\\', '/').split('/').pop()?.toLowerCase() ?? ''
+  return name === 'universaldevicetoolkit.networkproxy' || name.startsWith('universaldevicetoolkit.networkproxy.')
+}

--- a/UniversalDeviceToolkit.Electron/installer/i18n.mjs
+++ b/UniversalDeviceToolkit.Electron/installer/i18n.mjs
@@ -1,0 +1,81 @@
+const catalogs = {
+  'en-US': {
+    featuresTitle: 'Choose features',
+    featuresSubtitle: 'Required components stay installed. Optional modules can be left out.',
+    stepFeatures: 'Features',
+    requiredGroup: 'Required',
+    optionalGroup: 'Optional',
+    requiredHint: 'Always installed so the app can start.',
+    optionalHint: 'Included by default. Uncheck a module to omit it from this install.',
+    hostRuntime: 'Host runtime',
+    hostRuntimeDesc: 'Background service for settings, hardware, and device features.',
+    electronShell: 'Desktop shell',
+    electronShellDesc: 'The Universal Device Toolkit window.',
+    dashboard: 'Console',
+    dashboardDesc: 'Home dashboard.',
+    settings: 'Settings',
+    settingsDesc: 'Application settings.',
+    about: 'About',
+    aboutDesc: 'Version and project information.',
+    windowsOptimization: 'System optimization',
+    windowsOptimizationDesc: 'Cleanup, driver download, and related tools.',
+    networkAcceleration: 'Network acceleration',
+    networkAccelerationDesc: 'Optional local proxy worker. Requires System optimization.',
+    automation: 'Automation',
+    automationDesc: 'Automation pipelines.',
+    macro: 'Custom macro',
+    macroDesc: 'Keyboard and mouse macros.',
+    keyboard: 'Keyboard',
+    keyboardDesc: 'Keyboard backlight controls.',
+    pluginExtensions: 'Plugins & extensions',
+    pluginExtensionsDesc: 'Install and manage plugins.',
+    startInstall: 'Install',
+    featuresSummary: 'Features',
+    featuresSummaryFull: 'Full install',
+    featuresSummaryCustom: 'Custom selection'
+  },
+  'zh-CN': {
+    featuresTitle: '选择功能',
+    featuresSubtitle: '基础组件会始终安装。可选模块可以取消勾选。',
+    stepFeatures: '功能',
+    requiredGroup: '必选',
+    optionalGroup: '可选',
+    requiredHint: '应用启动所必需，无法取消。',
+    optionalHint: '默认全部勾选。取消勾选后，安装的应用不会显示对应界面。',
+    hostRuntime: '主机运行时',
+    hostRuntimeDesc: '后台服务，负责设置、硬件和设备功能。',
+    electronShell: '桌面程序',
+    electronShellDesc: 'Universal Device Toolkit 主窗口。',
+    dashboard: '控制台',
+    dashboardDesc: '主页仪表盘。',
+    settings: '设置',
+    settingsDesc: '应用程序设置。',
+    about: '关于',
+    aboutDesc: '版本与项目信息。',
+    windowsOptimization: '系统优化',
+    windowsOptimizationDesc: '清理、驱动下载及相关工具。',
+    networkAcceleration: '网络加速',
+    networkAccelerationDesc: '可选的本机代理组件。需要同时安装系统优化。',
+    automation: '自动化',
+    automationDesc: '自动化流程。',
+    macro: '自定义宏',
+    macroDesc: '键盘和鼠标宏。',
+    keyboard: '键盘',
+    keyboardDesc: '键盘背光控制。',
+    pluginExtensions: '插件扩展',
+    pluginExtensionsDesc: '安装和管理插件。',
+    startInstall: '开始安装',
+    featuresSummary: '功能',
+    featuresSummaryFull: '完整安装',
+    featuresSummaryCustom: '自定义选择'
+  }
+}
+
+export function installerLocale(language) {
+  return language === 'zh-CN' ? 'zh-CN' : 'en-US'
+}
+
+export function installerText(language, key) {
+  const locale = installerLocale(language)
+  return catalogs[locale][key] ?? catalogs['en-US'][key] ?? key
+}

--- a/UniversalDeviceToolkit.Electron/installer/main.mjs
+++ b/UniversalDeviceToolkit.Electron/installer/main.mjs
@@ -4,6 +4,7 @@ import { execFile, spawn } from 'node:child_process'
 import { promisify } from 'node:util'
 import { basename, dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { featureFlag, isNetworkProxySidecarFile, normalizeFeatures } from './features.mjs'
 
 const execFileAsync = promisify(execFile)
 const installerRoot = dirname(fileURLToPath(import.meta.url))
@@ -100,12 +101,13 @@ async function collectFiles(root) {
   return files
 }
 
-async function copyPayload(destination) {
+async function copyPayload(destination, features) {
   const files = await collectFiles(payloadRoot)
-  const totalBytes = files.reduce((sum, file) => sum + file.size, 0)
+  const selected = files.filter((file) => features.networkAcceleration || !isNetworkProxySidecarFile(file.relative))
+  const totalBytes = selected.reduce((sum, file) => sum + file.size, 0)
   let copiedBytes = 0
   await fs.mkdir(destination, { recursive: true })
-  for (const file of files) {
+  for (const file of selected) {
     const target = join(destination, file.relative)
     await fs.mkdir(dirname(target), { recursive: true })
     await fs.copyFile(file.path, target)
@@ -120,8 +122,19 @@ async function copyPayload(destination) {
   }
 }
 
-async function writeSelection(destination, language, deviceMode) {
-  const contents = `[installation]\nlanguage=${language}\ndeviceMode=${deviceMode}\n`
+async function writeSelection(destination, language, deviceMode, features) {
+  const contents = [
+    '[installation]',
+    `language=${language}`,
+    `deviceMode=${deviceMode}`,
+    `windowsOptimization=${featureFlag(features.windowsOptimization)}`,
+    `networkAcceleration=${featureFlag(features.networkAcceleration)}`,
+    `automation=${featureFlag(features.automation)}`,
+    `macro=${featureFlag(features.macro)}`,
+    `keyboard=${featureFlag(features.keyboard)}`,
+    `pluginExtensions=${featureFlag(features.pluginExtensions)}`,
+    ''
+  ].join('\n')
   await fs.writeFile(join(destination, 'installer-selection.ini'), contents, 'utf8')
 }
 
@@ -181,6 +194,7 @@ async function installApplication(options) {
   const destination = resolve(String(options?.destination ?? ''))
   const language = String(options?.language ?? '')
   const deviceMode = String(options?.deviceMode ?? '')
+  const features = normalizeFeatures(options?.features)
   if (!destination || destination === resolve(dirname(process.execPath))) throw new Error('Choose a different installation folder.')
   if (!validLanguages.has(language)) throw new Error('Unsupported installer language.')
   if (!validDeviceModes.has(deviceMode)) throw new Error('Unsupported device mode.')
@@ -188,8 +202,8 @@ async function installApplication(options) {
   isInstalling = true
   try {
     emitProgress({ phase: 'preparing', percent: 0, file: '' })
-    await copyPayload(destination)
-    await writeSelection(destination, language, deviceMode)
+    await copyPayload(destination, features)
+    await writeSelection(destination, language, deviceMode, features)
 
     const installedExe = join(destination, 'UniversalDeviceToolkit.exe')
     const uninstallExe = join(destination, 'uninstall.exe')

--- a/UniversalDeviceToolkit.Electron/installer/renderer.mjs
+++ b/UniversalDeviceToolkit.Electron/installer/renderer.mjs
@@ -1,3 +1,6 @@
+import { defaultFeatures, normalizeFeatures, OPTIONAL_FEATURES } from './features.mjs'
+import { installerText } from './i18n.mjs'
+
 const api = window.installerApi
 const appRoot = document.querySelector('#app')
 const languageOptions = [
@@ -16,6 +19,7 @@ const state = {
   destination: '',
   language: 'zh-CN',
   deviceMode: 'auto',
+  features: defaultFeatures(),
   installing: false,
   installedExecutable: '',
   progress: { percent: 0, file: '', message: '' },
@@ -78,8 +82,18 @@ function shell() {
   </div>`
 }
 
+function text(key) {
+  return installerText(state.language, key)
+}
+
 function renderSteps(active) {
-  const steps = [['welcome', '位置'], ['language', '语言'], ['device', '设备'], ['install', '安装']]
+  const steps = [
+    ['welcome', '位置'],
+    ['language', '语言'],
+    ['device', '设备'],
+    ['features', text('stepFeatures')],
+    ['install', '安装']
+  ]
   const activeIndex = steps.findIndex(([id]) => id === active)
   return `<nav class="steps" aria-label="安装进度">${steps.map(([, name], index) => `<div class="step ${index === activeIndex ? 'active' : ''} ${index < activeIndex ? 'done' : ''}" data-step="${index < activeIndex ? '' : index + 1}">${name}</div>`).join('')}</nav>`
 }
@@ -88,6 +102,7 @@ function renderPage(info) {
   if (state.page === 'uninstall') return renderUninstall(info)
   if (state.page === 'language') return renderLanguage()
   if (state.page === 'device') return renderDevice()
+  if (state.page === 'features') return renderFeatures()
   if (state.page === 'install') return renderInstall(info)
   if (state.page === 'complete') return renderComplete()
   return renderWelcome(info)
@@ -110,12 +125,39 @@ function renderDevice() {
   return `<h2 class="heading">设备选择</h2><p class="subtitle">选择启动时使用的设备支持模式。</p><div class="divider"></div>${renderSteps('device')}<section class="page"><div class="choice-grid" role="radiogroup" aria-label="设备支持模式">
     <button class="choice-card ${state.deviceMode === 'auto' ? 'selected' : ''}" data-device="auto" role="radio" aria-checked="${state.deviceMode === 'auto'}"><span class="choice-radio"></span><span><span class="choice-name">自动检测设备</span><span class="choice-description">启用完整的硬件监控和设备功能。</span></span><span class="choice-meta">推荐</span></button>
     <button class="choice-card ${state.deviceMode === 'basic' ? 'selected' : ''}" data-device="basic" role="radio" aria-checked="${state.deviceMode === 'basic'}"><span class="choice-radio"></span><span><span class="choice-name">基础模式</span><span class="choice-description">不读取硬件传感器，适用于受限环境。</span></span><span class="choice-meta">安全</span></button>
-  </div><div class="error-message">${escapeHtml(state.error)}</div></section>${footer('开始安装', true)}`
+  </div><div class="error-message">${escapeHtml(state.error)}</div></section>${footer('下一步', true)}`
+}
+
+function featureRow(id, locked) {
+  const selected = locked || state.features[id] === true
+  const disabled = locked || (id === 'networkAcceleration' && !state.features.windowsOptimization)
+  const classes = ['feature-row', selected ? 'selected' : '', locked ? 'locked' : '', disabled && !locked ? 'disabled' : '']
+    .filter(Boolean)
+    .join(' ')
+  return `<button type="button" class="${classes}" data-feature="${locked ? '' : id}" ${disabled ? 'disabled' : ''} role="checkbox" aria-checked="${selected}" aria-disabled="${disabled}">
+    <span class="feature-check" aria-hidden="true"></span>
+    <span><span class="feature-name">${escapeHtml(text(id))}</span><span class="feature-desc">${escapeHtml(text(`${id}Desc`))}</span></span>
+  </button>`
+}
+
+function renderFeatures() {
+  const required = ['hostRuntime', 'electronShell', 'dashboard', 'settings', 'about']
+  const optional = OPTIONAL_FEATURES
+  return `<h2 class="heading">${escapeHtml(text('featuresTitle'))}</h2><p class="subtitle">${escapeHtml(text('featuresSubtitle'))}</p><div class="divider"></div>${renderSteps('features')}
+    <section class="page"><div class="feature-groups">
+      <div class="feature-group"><div class="feature-group-title">${escapeHtml(text('requiredGroup'))}</div><div class="feature-group-hint">${escapeHtml(text('requiredHint'))}</div>${required.map((id) => featureRow(id, true)).join('')}</div>
+      <div class="feature-group"><div class="feature-group-title">${escapeHtml(text('optionalGroup'))}</div><div class="feature-group-hint">${escapeHtml(text('optionalHint'))}</div>${optional.map((id) => featureRow(id, false)).join('')}</div>
+    </div><div class="error-message">${escapeHtml(state.error)}</div></section>${footer(text('startInstall'), true)}`
+}
+
+function featuresSummaryLabel() {
+  const omitted = OPTIONAL_FEATURES.filter((id) => state.features[id] !== true)
+  return omitted.length === 0 ? text('featuresSummaryFull') : text('featuresSummaryCustom')
 }
 
 function renderInstall(info) {
   const progress = Math.max(0, Math.min(100, state.progress.percent))
-  return `<h2 class="heading">正在安装</h2><p class="subtitle">请稍候，Universal Device Toolkit 正在准备运行环境。</p><div class="divider"></div>${renderSteps('install')}<section class="page"><div class="install-summary"><div class="summary-line"><span>安装位置</span><strong>${escapeHtml(state.destination)}</strong></div><div class="summary-line"><span>语言</span><strong>${escapeHtml(languageOptions.find(([id]) => id === state.language)?.[1] ?? state.language)}</strong></div><div class="summary-line"><span>设备模式</span><strong>${state.deviceMode === 'auto' ? '自动检测设备' : '基础模式'}</strong></div></div><div class="progress-track"><div class="progress-bar" style="width:${progress}%"></div></div><div class="progress-caption"><span>${escapeHtml(state.progress.file || '正在复制应用文件...')}</span><span>${progress.toFixed(0)}%</span></div><div class="log-line">${escapeHtml(state.progress.message || `需要空间 ${formatBytes(info.payloadBytes)}`)}</div><div class="error-message">${escapeHtml(state.error)}</div></section><div class="footer"><button class="button-secondary" data-action="close" ${state.installing ? 'disabled' : ''}>取消</button></div>`
+  return `<h2 class="heading">正在安装</h2><p class="subtitle">请稍候，Universal Device Toolkit 正在准备运行环境。</p><div class="divider"></div>${renderSteps('install')}<section class="page"><div class="install-summary"><div class="summary-line"><span>安装位置</span><strong>${escapeHtml(state.destination)}</strong></div><div class="summary-line"><span>语言</span><strong>${escapeHtml(languageOptions.find(([id]) => id === state.language)?.[1] ?? state.language)}</strong></div><div class="summary-line"><span>设备模式</span><strong>${state.deviceMode === 'auto' ? '自动检测设备' : '基础模式'}</strong></div><div class="summary-line"><span>${escapeHtml(text('featuresSummary'))}</span><strong>${escapeHtml(featuresSummaryLabel())}</strong></div></div><div class="progress-track"><div class="progress-bar" style="width:${progress}%"></div></div><div class="progress-caption"><span>${escapeHtml(state.progress.file || '正在复制应用文件...')}</span><span>${progress.toFixed(0)}%</span></div><div class="log-line">${escapeHtml(state.progress.message || `需要空间 ${formatBytes(info.payloadBytes)}`)}</div><div class="error-message">${escapeHtml(state.error)}</div></section><div class="footer"><button class="button-secondary" data-action="close" ${state.installing ? 'disabled' : ''}>取消</button></div>`
 }
 
 function renderComplete() {
@@ -142,19 +184,26 @@ async function next() {
     if (!state.destination) { state.error = '请选择安装位置。'; render(); return }
     state.page = 'language'
   } else if (state.page === 'language') state.page = 'device'
-  else if (state.page === 'device') {
+  else if (state.page === 'device') state.page = 'features'
+  else if (state.page === 'features') {
+    state.features = normalizeFeatures(state.features)
     state.page = 'install'
     state.installing = true
     render()
     try {
-      const result = await api.install({ destination: state.destination, language: state.language, deviceMode: state.deviceMode })
+      const result = await api.install({
+        destination: state.destination,
+        language: state.language,
+        deviceMode: state.deviceMode,
+        features: state.features
+      })
       state.installedExecutable = result.executable
       state.installing = false
       state.page = 'complete'
       render()
     } catch (error) {
       state.installing = false
-      state.page = 'device'
+      state.page = 'features'
       state.error = error instanceof Error ? error.message : String(error)
       render()
     }
@@ -167,11 +216,21 @@ function back() {
   state.error = ''
   if (state.page === 'language') state.page = 'welcome'
   else if (state.page === 'device') state.page = 'language'
+  else if (state.page === 'features') state.page = 'device'
   render()
 }
 
+function toggleFeature(id) {
+  if (!OPTIONAL_FEATURES.includes(id)) return
+  if (id === 'networkAcceleration' && !state.features.windowsOptimization) return
+  state.features[id] = !state.features[id]
+  if (id === 'windowsOptimization' && !state.features.windowsOptimization) {
+    state.features.networkAcceleration = false
+  }
+}
+
 appRoot.addEventListener('click', async (event) => {
-  const target = event.target instanceof Element ? event.target.closest('[data-action], [data-language], [data-device]') : null
+  const target = event.target instanceof Element ? event.target.closest('[data-action], [data-language], [data-device], [data-feature]') : null
   if (!(target instanceof HTMLElement)) return
   if (target.dataset.action === 'minimize') api.minimize()
   else if (target.dataset.action === 'close') api.close()
@@ -187,6 +246,7 @@ appRoot.addEventListener('click', async (event) => {
     catch (error) { state.error = error instanceof Error ? error.message : String(error); render() }
   } else if (target.dataset.language) { state.language = target.dataset.language; render() }
   else if (target.dataset.device) { state.deviceMode = target.dataset.device; render() }
+  else if (target.dataset.feature) { toggleFeature(target.dataset.feature); render() }
 })
 
 appRoot.addEventListener('input', (event) => {

--- a/UniversalDeviceToolkit.Electron/installer/styles.css
+++ b/UniversalDeviceToolkit.Electron/installer/styles.css
@@ -167,6 +167,20 @@ button:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 .choice-description { display: block; margin-top: 5px; color: var(--muted); font-size: 13px; }
 .choice-meta { padding: 4px 8px; border-radius: 999px; background: color-mix(in srgb, var(--text) 6%, transparent); color: var(--muted); font-size: 12px; }
 .choice-card.selected .choice-meta { background: color-mix(in srgb, var(--accent) 16%, transparent); color: var(--text); }
+
+.feature-groups { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; min-height: 0; height: 100%; }
+.feature-group { min-height: 0; overflow: auto; padding: 12px 12px 8px; border: 1px solid var(--line); border-radius: 11px; background: var(--card-background); }
+.feature-group-title { font-size: 15px; font-weight: 700; }
+.feature-group-hint { margin: 4px 0 8px; color: var(--muted); font-size: 12px; line-height: 1.4; }
+.feature-row { display: grid; width: 100%; grid-template-columns: 18px 1fr; gap: 10px; align-items: start; padding: 7px 6px; border: 0; border-radius: 8px; background: transparent; color: inherit; text-align: left; }
+.feature-row:hover:not(:disabled) { background: var(--accent-soft); }
+.feature-row:disabled { cursor: default; }
+.feature-row.locked { opacity: .88; }
+.feature-row.disabled { opacity: .55; }
+.feature-check { width: 16px; height: 16px; margin-top: 2px; border: 2px solid var(--muted); border-radius: 4px; background: transparent; }
+.feature-row.selected .feature-check { border-color: var(--accent); background: var(--accent); box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--card) 70%, transparent); }
+.feature-name { display: block; font-size: 14px; font-weight: 600; }
+.feature-desc { display: block; margin-top: 2px; color: var(--muted); font-size: 12px; line-height: 1.35; }
 .language-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 9px; max-height: 300px; overflow: auto; padding-right: 4px; }
 .language-grid::-webkit-scrollbar { width: 10px; }
 .language-grid::-webkit-scrollbar-track { background: transparent; }

--- a/UniversalDeviceToolkit.Electron/src/main/index.ts
+++ b/UniversalDeviceToolkit.Electron/src/main/index.ts
@@ -911,7 +911,9 @@ app.whenReady().then(() => {
   installerSelection = readInstallerSelection()
   if (installerSelection != null) {
     console.log(
-      `[main] installer selection: language=${installerSelection.language}, deviceMode=${installerSelection.deviceMode}`
+      `[main] installer selection: language=${installerSelection.language}, deviceMode=${installerSelection.deviceMode}, features=${Object.entries(installerSelection.features)
+        .map(([key, enabled]) => `${key}=${enabled ? '1' : '0'}`)
+        .join(',')}`
     )
   }
   if (flags.isTraceEnabled) {

--- a/UniversalDeviceToolkit.Electron/src/main/installer-selection.ts
+++ b/UniversalDeviceToolkit.Electron/src/main/installer-selection.ts
@@ -1,8 +1,13 @@
 import { existsSync, readFileSync } from 'fs'
 import { join } from 'path'
 import {
+  isInstallerOptionalFeature,
   normalizeInstallerDeviceMode,
+  normalizeInstallerFeatures,
   normalizeInstallerLanguage,
+  parseInstallerFeatureFlag,
+  serializeInstallerFeaturesArgument,
+  type InstallerOptionalFeature,
   type InstallerSelection
 } from '../shared/installer-selection'
 
@@ -15,11 +20,12 @@ function installerSelectionPath(): string {
   return join(process.resourcesPath, '..', INSTALLER_SELECTION_FILE_NAME)
 }
 
-/** Parse the small INI file written by the per-machine NSIS installer. */
+/** Parse the small INI file written by the per-machine installer. */
 export function parseInstallerSelectionIni(contents: string): InstallerSelection | null {
   let section = ''
   let language: string | undefined
   let deviceMode: string | undefined
+  const rawFeatures: Partial<Record<InstallerOptionalFeature, boolean>> = {}
 
   for (const rawLine of contents.split(/\r?\n/)) {
     const line = rawLine.trim()
@@ -31,16 +37,25 @@ export function parseInstallerSelectionIni(contents: string): InstallerSelection
     if (section !== 'installation') continue
     const separator = line.indexOf('=')
     if (separator < 0) continue
-    const key = line.slice(0, separator).trim().toLowerCase()
+    const key = line.slice(0, separator).trim()
     const value = line.slice(separator + 1).trim()
-    if (key === 'language') language = value
-    if (key === 'devicemode') deviceMode = value
+    const normalizedKey = key.toLowerCase()
+    if (normalizedKey === 'language') language = value
+    if (normalizedKey === 'devicemode') deviceMode = value
+    if (isInstallerOptionalFeature(key)) {
+      const flag = parseInstallerFeatureFlag(value)
+      if (flag !== undefined) rawFeatures[key] = flag
+    }
   }
 
   const normalizedLanguage = normalizeInstallerLanguage(language)
   const normalizedDeviceMode = normalizeInstallerDeviceMode(deviceMode)
   if (normalizedLanguage == null || normalizedDeviceMode == null) return null
-  return { language: normalizedLanguage, deviceMode: normalizedDeviceMode }
+  return {
+    language: normalizedLanguage,
+    deviceMode: normalizedDeviceMode,
+    features: normalizeInstallerFeatures(rawFeatures)
+  }
 }
 
 export function readInstallerSelection(): InstallerSelection | null {
@@ -57,10 +72,14 @@ export function readInstallerSelection(): InstallerSelection | null {
 export function buildInstallerRendererArguments(selection: InstallerSelection): string[] {
   return [
     `--udt-installer-language=${selection.language}`,
-    `--udt-installer-device-mode=${selection.deviceMode}`
+    `--udt-installer-device-mode=${selection.deviceMode}`,
+    serializeInstallerFeaturesArgument(selection.features)
   ]
 }
 
 export function buildInstallerHostArguments(selection: InstallerSelection | null): string[] {
-  return selection?.deviceMode === 'basic' ? ['--no-hardware'] : []
+  const args: string[] = []
+  if (selection?.deviceMode === 'basic') args.push('--no-hardware')
+  if (selection != null && !selection.features.pluginExtensions) args.push('--no-plugins')
+  return args
 }

--- a/UniversalDeviceToolkit.Electron/src/main/tray.ts
+++ b/UniversalDeviceToolkit.Electron/src/main/tray.ts
@@ -1,6 +1,8 @@
 import { app, BrowserWindow, Tray, nativeImage, nativeTheme, screen, type Rectangle } from 'electron'
 import { existsSync } from 'fs'
 import { join } from 'path'
+import { isInstallerOptionalFeatureEnabled } from '../shared/installer-selection'
+import { readInstallerSelection } from './installer-selection'
 import { trayIconSvgForSymbol, trayNavSvg } from './tray-icons'
 import { localizePipelineName, setTrayLanguage, trayStrings } from './tray-i18n'
 import {
@@ -198,6 +200,7 @@ async function readBatteryBadge(): Promise<string | undefined> {
 
 async function buildPopupNodes(): Promise<TrayPopupNode[]> {
   const s = trayStrings()
+  const installerFeatures = readInstallerSelection()?.features
   const [visibility, quickActions, powerMode, batteryBadge] = await Promise.all([
     readNavigationVisibility(),
     readQuickActions(),
@@ -234,6 +237,7 @@ async function buildPopupNodes(): Promise<TrayPopupNode[]> {
   nodes.push({ type: 'separator' })
 
   for (const nav of NAV_ITEMS) {
+    if (nav.visibilityKey && !isInstallerOptionalFeatureEnabled(installerFeatures, nav.visibilityKey)) continue
     if (!isNavVisible(nav.visibilityKey, visibility)) continue
     nodes.push({
       type: 'item',

--- a/UniversalDeviceToolkit.Electron/src/preload/index.d.ts
+++ b/UniversalDeviceToolkit.Electron/src/preload/index.d.ts
@@ -5,6 +5,14 @@ export interface Bridge {
   installerSelection: {
     language: string
     deviceMode: 'auto' | 'basic'
+    features: {
+      windowsOptimization: boolean
+      networkAcceleration: boolean
+      automation: boolean
+      macro: boolean
+      keyboard: boolean
+      pluginExtensions: boolean
+    }
   } | null
   invoke: (method: string, params?: unknown) => Promise<unknown>
   getHostStatus: () => Promise<{

--- a/UniversalDeviceToolkit.Electron/src/renderer/src/App.tsx
+++ b/UniversalDeviceToolkit.Electron/src/renderer/src/App.tsx
@@ -1,6 +1,7 @@
-import { Suspense, lazy } from 'react'
+import { Suspense, lazy, type ReactNode } from 'react'
 import { Spin } from 'antd'
 import { Navigate, Route, Routes } from 'react-router-dom'
+import { isInstallerOptionalFeatureEnabled, type InstallerOptionalFeature } from '../../shared/installer-selection'
 import AppLayout from './layout/AppLayout'
 
 const DashboardPage = lazy(() => import('./pages/DashboardParityPage'))
@@ -21,6 +22,19 @@ function PageFallback(): React.JSX.Element {
   )
 }
 
+function InstalledFeatureRoute({
+  feature,
+  children
+}: {
+  feature: InstallerOptionalFeature
+  children: ReactNode
+}): React.JSX.Element {
+  if (!isInstallerOptionalFeatureEnabled(window.bridge?.installerSelection?.features, feature)) {
+    return <Navigate to="/dashboard" replace />
+  }
+  return <>{children}</>
+}
+
 export default function App(): React.JSX.Element {
   return (
     <Suspense fallback={<PageFallback />}>
@@ -29,12 +43,12 @@ export default function App(): React.JSX.Element {
           <Route path="/" element={<Navigate to="/dashboard" replace />} />
           <Route path="/dashboard" element={<DashboardPage />} />
           <Route path="/settings" element={<SettingsPage />} />
-          <Route path="/automation" element={<AutomationPage />} />
-          <Route path="/keyboard" element={<KeyboardBacklightPage />} />
-          <Route path="/macro" element={<MacroPage />} />
-          <Route path="/optimization" element={<WindowsOptimizationPage />} />
-          <Route path="/plugins" element={<PluginExtensionsPage />} />
-          <Route path="/plugins/:pluginId" element={<PluginPageView />} />
+          <Route path="/automation" element={<InstalledFeatureRoute feature="automation"><AutomationPage /></InstalledFeatureRoute>} />
+          <Route path="/keyboard" element={<InstalledFeatureRoute feature="keyboard"><KeyboardBacklightPage /></InstalledFeatureRoute>} />
+          <Route path="/macro" element={<InstalledFeatureRoute feature="macro"><MacroPage /></InstalledFeatureRoute>} />
+          <Route path="/optimization" element={<InstalledFeatureRoute feature="windowsOptimization"><WindowsOptimizationPage /></InstalledFeatureRoute>} />
+          <Route path="/plugins" element={<InstalledFeatureRoute feature="pluginExtensions"><PluginExtensionsPage /></InstalledFeatureRoute>} />
+          <Route path="/plugins/:pluginId" element={<InstalledFeatureRoute feature="pluginExtensions"><PluginPageView /></InstalledFeatureRoute>} />
           <Route path="/about" element={<AboutPage />} />
         </Route>
       </Routes>

--- a/UniversalDeviceToolkit.Electron/src/renderer/src/components/settings/NavigationItemsSetting.tsx
+++ b/UniversalDeviceToolkit.Electron/src/renderer/src/components/settings/NavigationItemsSetting.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { featuresApi } from '../../api/features'
 import { keyboardApi } from '../../api/keyboard'
 import { settingsApi } from '../../api/settings'
+import { isInstallerOptionalFeatureEnabled } from '../../../../shared/installer-selection'
 import { useSettingsStore } from '../../stores/settingsStore'
 import { SettingsCard } from './SettingsCard'
 import { SettingsLoadError } from './SettingsLoadError'
@@ -74,10 +75,18 @@ export default function NavigationItemsSetting(): React.JSX.Element {
     }
   }, [reloadToken])
 
+  const installerFeatures = window.bridge?.installerSelection?.features
+  const installerOmitted = NAVIGATION_ITEMS.some(
+    (item) => !isInstallerOptionalFeatureEnabled(installerFeatures, item.key)
+  )
   const visibleItems = useMemo(
     () =>
-      NAVIGATION_ITEMS.filter((item) => item.key !== 'keyboard' || keyboardSupported),
-    [keyboardSupported]
+      NAVIGATION_ITEMS.filter(
+        (item) =>
+          isInstallerOptionalFeatureEnabled(installerFeatures, item.key) &&
+          (item.key !== 'keyboard' || keyboardSupported)
+      ),
+    [installerFeatures, keyboardSupported]
   )
 
   const handleToggle = async (key: string, checked: boolean): Promise<void> => {
@@ -119,18 +128,23 @@ export default function NavigationItemsSetting(): React.JSX.Element {
           onRetry={() => setReloadToken((value) => value + 1)}
         />
       ) : (
-        <div className="udt-settings-toggle-grid" role="list">
-          {visibleItems.map((item) => (
-            <div key={item.key} className="udt-settings-toggle-grid__item" role="listitem">
-              <span className="udt-settings-toggle-grid__label">{t(item.labelKey)}</span>
-              <Switch
-                className="udt-settings-switch"
-                checked={visibility[item.key] === true}
-                onChange={(checked) => void handleToggle(item.key, checked)}
-              />
-            </div>
-          ))}
-        </div>
+        <>
+          {installerOmitted ? (
+            <p className="udt-settings-section__intro">{t('installer.features.omittedHint')}</p>
+          ) : null}
+          <div className="udt-settings-toggle-grid" role="list">
+            {visibleItems.map((item) => (
+              <div key={item.key} className="udt-settings-toggle-grid__item" role="listitem">
+                <span className="udt-settings-toggle-grid__label">{t(item.labelKey)}</span>
+                <Switch
+                  className="udt-settings-switch"
+                  checked={visibility[item.key] === true}
+                  onChange={(checked) => void handleToggle(item.key, checked)}
+                />
+              </div>
+            ))}
+          </div>
+        </>
       )}
     </SettingsCard>
   )

--- a/UniversalDeviceToolkit.Electron/src/renderer/src/i18n/locales/en-US.ts
+++ b/UniversalDeviceToolkit.Electron/src/renderer/src/i18n/locales/en-US.ts
@@ -27,6 +27,11 @@ const enUS = {
     app: {
       name: 'Universal Device Toolkit'
     },
+    installer: {
+      features: {
+        omittedHint: 'Some pages were not selected during setup, so they stay hidden.'
+      }
+    },
     titlebar: {
       log: 'Log',
       openLogs: 'Open logs folder',

--- a/UniversalDeviceToolkit.Electron/src/renderer/src/i18n/locales/zh-CN.ts
+++ b/UniversalDeviceToolkit.Electron/src/renderer/src/i18n/locales/zh-CN.ts
@@ -5,6 +5,11 @@ export default withEnglishFallback({
     app: {
       name: '通用设备工具箱',
     },
+    installer: {
+      features: {
+        omittedHint: '部分页面未在安装时选择，因此不会显示。',
+      },
+    },
     titlebar: {
       log: '日志',
       openLogs: '打开日志文件夹',

--- a/UniversalDeviceToolkit.Electron/src/renderer/src/layout/AppLayout.tsx
+++ b/UniversalDeviceToolkit.Electron/src/renderer/src/layout/AppLayout.tsx
@@ -29,6 +29,7 @@ import UtilsModalHost from '../components/utils/UtilsModalHost'
 import UnsupportedDeviceGate from '../components/utils/UnsupportedDeviceGate'
 import { openStatusModal } from '../components/utils/StatusModal'
 import { on } from '../api/bridge'
+import { isInstallerOptionalFeatureEnabled } from '../../../shared/installer-selection'
 import { useSettingsStore } from '../stores/settingsStore'
 import WindowBackdropController from '../theme/WindowBackdropController'
 import './NavigationParity.css'
@@ -158,6 +159,7 @@ export default function AppLayout(): React.JSX.Element {
     const app = (scopes.application ?? {}) as Record<string, unknown>
     return ((app.NavigationItemsVisibility as Record<string, boolean> | undefined) ?? {})
   }, [scopes.application])
+  const installerFeatures = window.bridge?.installerSelection?.features
 
   const isNavItemVisible = useCallback(
     (item: NavItemDef): boolean => {
@@ -172,11 +174,13 @@ export default function AppLayout(): React.JSX.Element {
         '/about': 'about'
       }
       const pageTag: string = pageTagMap[item.key] ?? item.key.replace('/', '')
-      if (pageTag === 'dashboard' || pageTag === 'settings' || pageTag === 'pluginExtensions') return true
+      if (pageTag === 'dashboard' || pageTag === 'settings') return true
+      if (!isInstallerOptionalFeatureEnabled(installerFeatures, pageTag)) return false
+      if (pageTag === 'pluginExtensions') return true
       if (navVisibility[pageTag] === false) return false
       return true
     },
-    [navVisibility]
+    [installerFeatures, navVisibility]
   )
 
   const visibleMainItems = useMemo(() => MAIN_ITEMS.filter(isNavItemVisible), [isNavItemVisible])
@@ -283,6 +287,16 @@ export default function AppLayout(): React.JSX.Element {
   const handleResizerDoubleClick = useCallback((): void => {
     setCollapsed((prev) => !prev)
   }, [])
+
+  useEffect(() => {
+    const knownHidden = [...MAIN_ITEMS, ...FOOTER_ITEMS].some(
+      (item) => isRouteActive(location.pathname, item.key) && !isNavItemVisible(item)
+    )
+    const pluginsHidden =
+      location.pathname.startsWith('/plugins') &&
+      !isInstallerOptionalFeatureEnabled(installerFeatures, 'pluginExtensions')
+    if (knownHidden || pluginsHidden) navigate('/dashboard', { replace: true })
+  }, [installerFeatures, isNavItemVisible, location.pathname, navigate])
 
   // Tray navigation (Electron TrayHelper → NavigationStore.Navigate) and optional
   // status popup (legacy Electron-only; not part of the original tray menu).

--- a/UniversalDeviceToolkit.Electron/src/renderer/src/pages/WindowsOptimizationPage.tsx
+++ b/UniversalDeviceToolkit.Electron/src/renderer/src/pages/WindowsOptimizationPage.tsx
@@ -19,6 +19,7 @@ import type {
   OptimizationCategoryDefinition
 } from '../api/optimization'
 import { useDriverStore } from '../stores/driverStore'
+import { isInstallerOptionalFeatureEnabled } from '../../../shared/installer-selection'
 import { localizeHostError } from '../api/bridge'
 import { useOptimizationStore } from '../stores/optimizationStore'
 import { SkeletonCard, SkeletonList } from '../components/Skeleton'
@@ -41,6 +42,7 @@ import {
   resolveActionError,
   runExclusivePoll,
   shouldShowEmptyPlaceholder,
+  visibleOptimizationTabs,
   type OptimizationTabKey
 } from '../utils/optimizationPresentation'
 import { openActionDetails } from '../components/utils/ActionDetailsModal'
@@ -589,7 +591,7 @@ const TAB_FALLBACK_KEYS: Record<TabKey, string> = {
   gameBoost: 'optimization.tabs.gameBoost'
 }
 
-const TABS: TabKey[] = ['optimization', 'cleanup', 'driverDownload', 'networkAcceleration', 'gameBoost']
+const TABS: OptimizationTabKey[] = ['optimization', 'cleanup', 'driverDownload', 'networkAcceleration', 'gameBoost']
 
 export default function WindowsOptimizationPage(): React.JSX.Element {
   const { t } = useTranslation()
@@ -608,11 +610,23 @@ export default function WindowsOptimizationPage(): React.JSX.Element {
   const [cleanupSelectedKeys, setCleanupSelectedKeys] = useState<string[]>([])
   const [chromeBusy, setChromeBusy] = useState(false)
   const cleanupDefaultsApplied = useRef(false)
+  const networkAccelerationInstalled = isInstallerOptionalFeatureEnabled(
+    window.bridge?.installerSelection?.features,
+    'networkAcceleration'
+  )
+  const visibleTabs = useMemo(
+    () => visibleOptimizationTabs(TABS, networkAccelerationInstalled),
+    [networkAccelerationInstalled]
+  )
 
   useEffect(() => {
     void load()
-    void loadNetwork()
-  }, [load, loadNetwork])
+    if (networkAccelerationInstalled) void loadNetwork()
+  }, [load, loadNetwork, networkAccelerationInstalled])
+
+  useEffect(() => {
+    if (!visibleTabs.includes(tab)) setTab(visibleTabs[0] ?? 'optimization')
+  }, [tab, visibleTabs])
 
   useEffect(() => {
     if (cleanupDefaultsApplied.current || categories.length === 0) return
@@ -763,7 +777,7 @@ export default function WindowsOptimizationPage(): React.JSX.Element {
 
       <div className="udt-opt-chrome">
         <div className="udt-segmented-nav" role="tablist" aria-label={t('optimization.title')}>
-          {TABS.map((key) => (
+          {visibleTabs.map((key) => (
             <button
               key={key}
               type="button"

--- a/UniversalDeviceToolkit.Electron/src/renderer/src/utils/optimizationPresentation.ts
+++ b/UniversalDeviceToolkit.Electron/src/renderer/src/utils/optimizationPresentation.ts
@@ -13,6 +13,14 @@ export type OptimizationTabKey =
   | 'networkAcceleration'
   | 'gameBoost'
 
+export function visibleOptimizationTabs(
+  tabs: readonly OptimizationTabKey[],
+  networkAccelerationInstalled: boolean
+): OptimizationTabKey[] {
+  if (networkAccelerationInstalled) return [...tabs]
+  return tabs.filter((tab) => tab !== 'networkAcceleration')
+}
+
 export const NETWORK_ACCELERATION_MODES = [
   'Off',
   'SystemProxy',

--- a/UniversalDeviceToolkit.Electron/src/shared/installer-selection.ts
+++ b/UniversalDeviceToolkit.Electron/src/shared/installer-selection.ts
@@ -1,5 +1,5 @@
 /**
- * Values exchanged between the NSIS setup pages and the Electron processes.
+ * Values exchanged between the setup wizard and the Electron processes.
  * Keep this module platform-neutral so both the main and preload bundles can
  * validate installer input without sharing filesystem or Electron code.
  */
@@ -34,9 +34,96 @@ export const INSTALLER_LANGUAGES = [
 export type InstallerLanguage = (typeof INSTALLER_LANGUAGES)[number]
 export type InstallerDeviceMode = 'auto' | 'basic'
 
+/** Optional modules the installer can omit. Required pieces are never listed. */
+export const INSTALLER_OPTIONAL_FEATURES = [
+  'windowsOptimization',
+  'networkAcceleration',
+  'automation',
+  'macro',
+  'keyboard',
+  'pluginExtensions'
+] as const
+
+export type InstallerOptionalFeature = (typeof INSTALLER_OPTIONAL_FEATURES)[number]
+
+export type InstallerFeatures = Record<InstallerOptionalFeature, boolean>
+
 export interface InstallerSelection {
   language: InstallerLanguage
   deviceMode: InstallerDeviceMode
+  features: InstallerFeatures
+}
+
+export function defaultInstallerFeatures(): InstallerFeatures {
+  return {
+    windowsOptimization: true,
+    networkAcceleration: true,
+    automation: true,
+    macro: true,
+    keyboard: true,
+    pluginExtensions: true
+  }
+}
+
+export function isInstallerOptionalFeature(value: string): value is InstallerOptionalFeature {
+  return (INSTALLER_OPTIONAL_FEATURES as readonly string[]).includes(value)
+}
+
+/**
+ * Missing keys stay on (full install / older INI files). Network acceleration
+ * is a tab plus the NetworkProxy sidecar, so it cannot be installed without
+ * the System Optimization page that hosts it.
+ */
+export function normalizeInstallerFeatures(
+  raw: Partial<Record<string, boolean>> | null | undefined
+): InstallerFeatures {
+  const features = defaultInstallerFeatures()
+  if (raw == null) return features
+  for (const key of INSTALLER_OPTIONAL_FEATURES) {
+    if (raw[key] === false) features[key] = false
+  }
+  if (!features.windowsOptimization) features.networkAcceleration = false
+  return features
+}
+
+/** Unrecognized or missing feature names are treated as installed. */
+export function isInstallerOptionalFeatureEnabled(
+  features: InstallerFeatures | null | undefined,
+  feature: string
+): boolean {
+  if (features == null || !isInstallerOptionalFeature(feature)) return true
+  return features[feature] !== false
+}
+
+export function parseInstallerFeatureFlag(value: string | undefined): boolean | undefined {
+  if (value == null) return undefined
+  const normalized = value.trim().toLowerCase()
+  if (normalized === '0' || normalized === 'false' || normalized === 'no' || normalized === 'off') {
+    return false
+  }
+  if (normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'on') {
+    return true
+  }
+  return undefined
+}
+
+export function serializeInstallerFeaturesArgument(features: InstallerFeatures): string {
+  const enabled = INSTALLER_OPTIONAL_FEATURES.filter((key) => features[key])
+  return `--udt-installer-features=${enabled.join(',')}`
+}
+
+export function parseInstallerFeaturesArgument(value: string): InstallerFeatures {
+  const selected = new Set(
+    value
+      .split(',')
+      .map((item) => item.trim())
+      .filter((item) => item.length > 0)
+  )
+  const raw: Partial<Record<InstallerOptionalFeature, boolean>> = {}
+  for (const key of INSTALLER_OPTIONAL_FEATURES) {
+    raw[key] = selected.has(key)
+  }
+  return normalizeInstallerFeatures(raw)
 }
 
 export function normalizeInstallerLanguage(value: string | undefined): InstallerLanguage | null {
@@ -51,21 +138,31 @@ export function normalizeInstallerDeviceMode(value: string | undefined): Install
   return null
 }
 
-/** Parse only the two explicit, validated switches passed by Electron main. */
+/** Sidecar files the installer can omit when Network Acceleration is unchecked. */
+export function isNetworkProxySidecarFile(relativePath: string): boolean {
+  const name = relativePath.replaceAll('\\', '/').split('/').pop()?.toLowerCase() ?? ''
+  return name === 'universaldevicetoolkit.networkproxy' || name.startsWith('universaldevicetoolkit.networkproxy.')
+}
+
+/** Parse the explicit, validated switches passed by Electron main. */
 export function parseInstallerSelectionArguments(args: readonly string[]): InstallerSelection | null {
   let language: InstallerLanguage | null = null
   let deviceMode: InstallerDeviceMode | null = null
+  let features: InstallerFeatures | undefined
 
   for (const argument of args) {
     const languagePrefix = '--udt-installer-language='
     const deviceModePrefix = '--udt-installer-device-mode='
+    const featuresPrefix = '--udt-installer-features='
     if (argument.startsWith(languagePrefix)) {
       language = normalizeInstallerLanguage(argument.slice(languagePrefix.length))
     } else if (argument.startsWith(deviceModePrefix)) {
       deviceMode = normalizeInstallerDeviceMode(argument.slice(deviceModePrefix.length))
+    } else if (argument.startsWith(featuresPrefix)) {
+      features = parseInstallerFeaturesArgument(argument.slice(featuresPrefix.length))
     }
   }
 
   if (language == null || deviceMode == null) return null
-  return { language, deviceMode }
+  return { language, deviceMode, features: features ?? defaultInstallerFeatures() }
 }

--- a/UniversalDeviceToolkit.Electron/tests/installerSelection.test.mjs
+++ b/UniversalDeviceToolkit.Electron/tests/installerSelection.test.mjs
@@ -53,7 +53,7 @@ test('installer selection arguments accept only supported language and device va
       '--udt-installer-language=ja',
       '--udt-installer-device-mode=basic'
     ])),
-    JSON.stringify({ language: 'ja', deviceMode: 'basic' })
+    JSON.stringify({ language: 'ja', deviceMode: 'basic', features: shared.defaultInstallerFeatures() })
   )
   assert.equal(
     shared.parseInstallerSelectionArguments([
@@ -73,7 +73,43 @@ test('installer INI parser ignores unrelated sections and rejects incomplete inp
       'language=ru',
       'deviceMode=auto'
     ].join('\n'))),
-    JSON.stringify({ language: 'ru', deviceMode: 'auto' })
+    JSON.stringify({ language: 'ru', deviceMode: 'auto', features: shared.defaultInstallerFeatures() })
   )
   assert.equal(main.parseInstallerSelectionIni('[installation]\nlanguage=en'), null)
+})
+
+test('installer feature flags default on and treat missing keys as a full install', () => {
+  const omitted = shared.parseInstallerFeaturesArgument('automation,macro')
+  assert.equal(omitted.automation, true)
+  assert.equal(omitted.macro, true)
+  assert.equal(omitted.windowsOptimization, false)
+  assert.equal(omitted.networkAcceleration, false)
+  assert.equal(omitted.keyboard, false)
+  assert.equal(omitted.pluginExtensions, false)
+  assert.equal(shared.isInstallerOptionalFeatureEnabled(null, 'windowsOptimization'), true)
+  assert.equal(shared.isInstallerOptionalFeatureEnabled(omitted, 'windowsOptimization'), false)
+  assert.equal(shared.isInstallerOptionalFeatureEnabled(omitted, 'dashboard'), true)
+  assert.equal(shared.isNetworkProxySidecarFile('resources/host/UniversalDeviceToolkit.NetworkProxy.exe'), true)
+  assert.equal(shared.isNetworkProxySidecarFile('resources/host/UniversalDeviceToolkit.Host.exe'), false)
+})
+
+test('installer INI parser honors optional feature checkboxes and caps network acceleration', () => {
+  const parsed = main.parseInstallerSelectionIni([
+    '[installation]',
+    'language=en',
+    'deviceMode=auto',
+    'windowsOptimization=0',
+    'networkAcceleration=1',
+    'automation=1',
+    'macro=0',
+    'keyboard=1',
+    'pluginExtensions=0'
+  ].join('\n'))
+  assert.equal(parsed.features.windowsOptimization, false)
+  assert.equal(parsed.features.networkAcceleration, false)
+  assert.equal(parsed.features.automation, true)
+  assert.equal(parsed.features.macro, false)
+  assert.equal(parsed.features.pluginExtensions, false)
+  assert.equal(JSON.stringify(main.buildInstallerHostArguments(parsed)), JSON.stringify(['--no-plugins']))
+  assert.ok(main.buildInstallerRendererArguments(parsed).some((argument) => argument.startsWith('--udt-installer-features=')))
 })

--- a/UniversalDeviceToolkit.Electron/tests/installerUi.test.mjs
+++ b/UniversalDeviceToolkit.Electron/tests/installerUi.test.mjs
@@ -31,6 +31,14 @@ const styleSource = readFileSync(
   fileURLToPath(new URL('../installer/styles.css', import.meta.url)),
   'utf8'
 )
+const i18nSource = readFileSync(
+  fileURLToPath(new URL('../installer/i18n.mjs', import.meta.url)),
+  'utf8'
+)
+const featuresSource = readFileSync(
+  fileURLToPath(new URL('../installer/features.mjs', import.meta.url)),
+  'utf8'
+)
 
 test('installer uses a real Windows four-pane icon for the platform badge', () => {
   assert.match(rendererSource, /class="platform-icon"/)
@@ -45,6 +53,8 @@ test('installer keeps the reference visual language and setup choices', () => {
   assert.match(rendererSource, /准备安装/)
   assert.match(rendererSource, /语言选择/)
   assert.match(rendererSource, /设备选择/)
+  assert.match(rendererSource, /featuresTitle/)
+  assert.match(rendererSource, /data-feature/)
   assert.match(rendererSource, /需要管理员权限/)
   assert.doesNotMatch(rendererSource, /不会修改设备设置，安装后由你控制/)
   assert.doesNotMatch(rendererSource, /安装器只保存你的选择，不会修改设备配置/)
@@ -62,6 +72,22 @@ test('installer keeps the reference visual language and setup choices', () => {
   assert.match(styleSource, /prefers-reduced-motion:\s*reduce/)
   assert.match(styleSource, /\.choice-description\s*\{[^}]*display:\s*block/)
   assert.match(styleSource, /\.brand-panel\s*\{/)
+})
+
+test('custom installer feature page persists optional modules and can omit NetworkProxy', () => {
+  assert.match(i18nSource, /选择功能/)
+  assert.match(i18nSource, /Choose features/)
+  assert.match(i18nSource, /系统优化/)
+  assert.match(i18nSource, /网络加速/)
+  assert.match(featuresSource, /windowsOptimization/)
+  assert.match(featuresSource, /networkAcceleration/)
+  assert.match(mainSource, /normalizeFeatures/)
+  assert.match(mainSource, /isNetworkProxySidecarFile/)
+  assert.match(mainSource, /installer-selection.ini/)
+  assert.match(installerSource, /Page custom UdtFeaturesPage UdtFeaturesLeave/)
+  assert.match(installerSource, /windowsOptimization/)
+  assert.match(installerSource, /UniversalDeviceToolkit.NetworkProxy.exe/)
+  assert.match(styleSource, /\.feature-groups\s*\{/)
 })
 
 test('custom installer rebuilds its application payload before packaging', () => {

--- a/UniversalDeviceToolkit.Electron/tests/optimization.test.mjs
+++ b/UniversalDeviceToolkit.Electron/tests/optimization.test.mjs
@@ -59,7 +59,8 @@ const {
   presentActionNotification,
   resolveActionError,
   runExclusivePoll,
-  shouldShowEmptyPlaceholder
+  shouldShowEmptyPlaceholder,
+  visibleOptimizationTabs
 } = await import('../src/renderer/src/utils/optimizationPresentation.ts')
 
 function action(key, applied, recommended = false) {
@@ -643,4 +644,15 @@ test('action notifications keep a short title and put the host detail in the mes
   assert.deepEqual(presentActionNotification('  Host detail  ', '  '), {
     title: 'Host detail'
   })
+})
+
+test('optimization tabs hide network acceleration when it was not installed', () => {
+  const tabs = ['optimization', 'cleanup', 'driverDownload', 'networkAcceleration', 'gameBoost']
+  assert.deepEqual(visibleOptimizationTabs(tabs, true), tabs)
+  assert.deepEqual(visibleOptimizationTabs(tabs, false), [
+    'optimization',
+    'cleanup',
+    'driverDownload',
+    'gameBoost'
+  ])
 })

--- a/UniversalDeviceToolkit.Tests.Contracts/Utils/PackagingGuardTests.cs
+++ b/UniversalDeviceToolkit.Tests.Contracts/Utils/PackagingGuardTests.cs
@@ -123,5 +123,9 @@ public sealed class PackagingGuardTests
         script.Should().Contain("$INSTDIR\\installer-selection.ini");
         script.Should().Contain("WriteINIStr");
         script.Should().Contain("deviceMode");
+        script.Should().Contain("Page custom UdtFeaturesPage UdtFeaturesLeave");
+        script.Should().Contain("windowsOptimization");
+        script.Should().Contain("networkAcceleration");
+        script.Should().Contain("UniversalDeviceToolkit.NetworkProxy.exe");
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Adds **选择功能 / Choose features** to the **custom Electron installer** (`UniversalDeviceToolkit.Electron/installer/`), which is what Full offline `UniversalDeviceToolkitSetup.exe` actually runs (`custom-installer.yml` portable).
- Wizard order: 位置 → 语言 → 设备 → **选择功能** → 安装. Same chrome as the other Electron installer pages.
- Required (locked): Host runtime, desktop shell, Console, Settings, About.
- Optional (default on): 系统优化, 网络加速 (needs 系统优化), 自动化, 自定义宏, 键盘, 插件扩展.
- Writes `{installDir}/installer-selection.ini`. The app hides omitted nav; unchecked 网络加速 skips NetworkProxy; unchecked 插件扩展 starts Host with `--no-plugins`.
- NSIS (`installer.nsh`) has a matching page only for **Online** setup. Inno is retired. Missing INI (dev/zip) keeps full install.

## Verification
- [ ] `dotnet build UniversalDeviceToolkit.sln --configuration Release`
- [ ] `dotnet test UniversalDeviceToolkit.Tests/UniversalDeviceToolkit.Tests.csproj --framework net10.0-windows`
- [ ] CHANGELOG.md updated for user-visible changes
- [x] Electron installer + selection tests (`installerSelection`, `installerUi`, `optimization`)
- [x] Renderer/main `tsc --noEmit`

## Plugin Changes (if applicable)
- N/A (optional 插件扩展 only gates Host `--no-plugins` and the Plugins nav page)

## Notes
- Network acceleration is the existing optimization tab plus NetworkProxy, not a new product.
- Optional pages stay in the binary and are visibility-gated except NetworkProxy copy/delete.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed50ebbe-b5f4-4422-ae55-6fbd2d616fe9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed50ebbe-b5f4-4422-ae55-6fbd2d616fe9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

