### PR TITLE
feat(release): add experimental-packages workflow for macOS/Linux assets

### DIFF
--- a/.github/workflows/experimental-packages.yml
+++ b/.github/workflows/experimental-packages.yml
@@ -1,0 +1,209 @@
+name: Experimental Packages
+
+# Builds the EXPERIMENTAL macOS DMG (arm64 + x64) and Linux AppImage/DEB (x64)
+# for an existing vX.Y.Z release tag, audits them with the same footprint
+# budgets as package-footprint.yml, and (optionally) attaches them to that
+# GitHub release together with a dedicated SHA256 manifest.
+#
+# These artifacts are NOT official products (see Docs/DEPLOYMENT.md). macOS
+# DMGs are unsigned/not notarized (no Developer ID configured) and Linux
+# packages are unsigned. Release.yml remains the only official (Windows)
+# release pipeline; this workflow never creates releases or tags.
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Existing vX.Y.Z release tag to build experimental macOS/Linux assets for"
+        required: true
+        type: string
+      attach_to_release:
+        description: "Attach DMG/AppImage/DEB and the experimental SHA256 manifest to that GitHub release"
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: ${{ matrix.os }} (${{ matrix.runtimeIdentifier }}) experimental package
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            platform: linux
+            runtimeIdentifier: linux-x64
+            electronPlatform: --linux
+            electronTargets: AppImage deb
+            electronArchitecture: --x64
+          - os: macos-15
+            platform: macos
+            runtimeIdentifier: osx-arm64
+            electronPlatform: --mac
+            electronTargets: dmg
+            electronArchitecture: --arm64
+          - os: macos-15-intel
+            platform: macos
+            runtimeIdentifier: osx-x64
+            electronPlatform: --mac
+            electronTargets: dmg
+            electronArchitecture: --x64
+
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.release_tag }}
+
+      - name: Verify tag matches Directory.Build.props version
+        shell: pwsh
+        run: |
+          [xml]$props = Get-Content -Raw 'Directory.Build.props'
+          $group = $props.Project.PropertyGroup | Select-Object -First 1
+
+          $releaseVersion = [string]$group.ReleaseVersion
+          if ([string]::IsNullOrWhiteSpace($releaseVersion) -or $releaseVersion -match '\$\(') {
+            $releaseVersion = "$($group.MajorVersion).$($group.MinorVersion).$($group.PatchVersion)"
+          }
+
+          $tagVersion = '${{ inputs.release_tag }}'.Trim() -replace '^v', ''
+          $normalizedTagVersion = if ($tagVersion -match '^(\d+\.\d+\.\d+)') { $Matches[1] } else { $tagVersion }
+          if ($normalizedTagVersion -ne $releaseVersion) {
+            throw "Tag version '$tagVersion' does not match Directory.Build.props version '$releaseVersion'."
+          }
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Setup Node 22
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: UniversalDeviceToolkit.Electron/package-lock.json
+
+      - name: Install Electron build dependencies
+        working-directory: UniversalDeviceToolkit.Electron
+        run: npm ci
+
+      - name: Publish and prune self-contained Host (${{ matrix.runtimeIdentifier }})
+        shell: pwsh
+        run: |
+          $expectedArchitecture = if ('${{ matrix.runtimeIdentifier }}' -like '*arm64') { 'Arm64' } else { 'X64' }
+          $actualArchitecture = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()
+          if ($actualArchitecture -ne $expectedArchitecture) {
+            throw "Runner architecture '$actualArchitecture' does not match '${{ matrix.runtimeIdentifier }}'."
+          }
+
+          $env:UDT_PLATFORM = '${{ matrix.platform }}'
+          $project = 'UniversalDeviceToolkit.Host/UniversalDeviceToolkit.Host.csproj'
+          $publishPath = Join-Path $PWD 'UniversalDeviceToolkit.Host/publish/${{ matrix.runtimeIdentifier }}'
+          dotnet restore $project --runtime '${{ matrix.runtimeIdentifier }}' --force-evaluate
+          if ($LASTEXITCODE -ne 0) { throw 'Host restore failed.' }
+          dotnet publish $project --configuration Release --runtime '${{ matrix.runtimeIdentifier }}' --self-contained true --no-restore --output $publishPath
+          if ($LASTEXITCODE -ne 0) { throw 'Host publish failed.' }
+          ./Scripts/Prune-ShippingFootprint.ps1 -PayloadPath $publishPath -RuntimeIdentifier '${{ matrix.runtimeIdentifier }}' -AllowedCultures 'ar;bg;cs;de;el;en;es;fr;hu;it;ja;lv;nl-nl;pl;pt;pt-br;ro;ru;sk;tr;uk;uz-latn-uz;vi;zh-hans;zh-hant'
+
+      - name: Smoke Host JSON-RPC
+        shell: pwsh
+        run: |
+          $hostPath = Join-Path $PWD 'UniversalDeviceToolkit.Host/publish/${{ matrix.runtimeIdentifier }}/UniversalDeviceToolkit.Host'
+          if (-not (Test-Path -LiteralPath $hostPath -PathType Leaf)) {
+            throw "Published Host executable is missing: $hostPath"
+          }
+          node UniversalDeviceToolkit.Electron/scripts/smoke-host.mjs $hostPath
+
+      - name: Build and package Electron product
+        working-directory: UniversalDeviceToolkit.Electron
+        shell: pwsh
+        run: |
+          npm run typecheck
+          if ($LASTEXITCODE -ne 0) { throw 'Electron typecheck failed.' }
+          npm test
+          if ($LASTEXITCODE -ne 0) { throw 'Electron tests failed.' }
+          npm run build
+          if ($LASTEXITCODE -ne 0) { throw 'Electron production build failed.' }
+          $arguments = @('--config', 'electron-builder.yml', '${{ matrix.electronPlatform }}')
+          $arguments += '${{ matrix.electronTargets }}' -split ' '
+          $arguments += @('${{ matrix.electronArchitecture }}', '--publish', 'never')
+          & npx electron-builder @arguments
+          if ($LASTEXITCODE -ne 0) { throw 'Electron package build failed.' }
+
+      - name: Enforce distributable budgets
+        working-directory: UniversalDeviceToolkit.Electron
+        shell: pwsh
+        run: |
+          $artifacts = @(Get-ChildItem -LiteralPath dist -File | Where-Object { $_.Extension -in @('.dmg', '.AppImage', '.deb') })
+          if ($artifacts.Count -eq 0) { throw 'Electron Builder produced no distributable artifacts.' }
+          node scripts/package-footprint.mjs @($artifacts.FullName)
+          if ($LASTEXITCODE -ne 0) { throw 'Distributable footprint audit failed.' }
+
+      - name: Upload experimental packages
+        uses: actions/upload-artifact@v7
+        with:
+          name: experimental-packages-${{ matrix.runtimeIdentifier }}-${{ github.run_id }}
+          path: |
+            UniversalDeviceToolkit.Electron/dist/*.dmg
+            UniversalDeviceToolkit.Electron/dist/*.AppImage
+            UniversalDeviceToolkit.Electron/dist/*.deb
+          if-no-files-found: error
+
+      - name: Upload footprint reports
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: experimental-footprint-${{ matrix.runtimeIdentifier }}-${{ github.run_id }}
+          path: UniversalDeviceToolkit.Electron/dist/footprint/*.json
+          if-no-files-found: warn
+
+  attach:
+    name: Attach experimental assets to release
+    needs: build
+    if: ${{ inputs.attach_to_release }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Verify release exists
+        run: gh release view '${{ inputs.release_tag }}' --repo '${{ github.repository }}' --json tagName --jq .tagName
+
+      - name: Download experimental packages
+        uses: actions/download-artifact@v8
+        with:
+          pattern: experimental-packages-*-${{ github.run_id }}
+          path: packages
+          merge-multiple: true
+
+      - name: Generate experimental SHA256 manifest
+        run: |
+          set -euo pipefail
+          cd packages
+          shopt -s nullglob
+          files=(*.dmg *.AppImage *.deb)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo 'No experimental packages were downloaded.' >&2
+            exit 1
+          fi
+          version="$(echo '${{ inputs.release_tag }}' | sed 's/^v//')"
+          manifest="UniversalDeviceToolkit_v${version}_Experimental_SHA256.txt"
+          sha256sum "${files[@]}" > "$manifest"
+          cat "$manifest"
+
+      - name: Upload assets to release
+        run: |
+          set -euo pipefail
+          cd packages
+          gh release upload '${{ inputs.release_tag }}' \
+            --repo '${{ github.repository }}' \
+            --clobber \
+            *.dmg *.AppImage *.deb UniversalDeviceToolkit_v*_Experimental_SHA256.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added / 新增
+- New manually dispatched `experimental-packages.yml` workflow builds the experimental macOS DMGs (arm64 + x64) and Linux AppImage/DEB (x64) for an existing release tag, audits them against the package footprint budgets, and can attach them to that GitHub release with a dedicated `*_Experimental_SHA256.txt` manifest. These assets stay experimental (unsigned, no auto-update, no hardware control); `Release.yml` remains the only official Windows release pipeline.
 - **Cursor & Pointer (built-in)**: Former CustomMouse plugin capabilities are now native Host features — custom high-DPI cursor themes (`W11-CC-V2.2-HDPI` shipped with the host), per-UI-scale cursor sizing, and pointer speed controls on the Mouse page. Existing settings from the retired plugin's `config.json` are imported automatically.
 
 ### Changed / 变更

--- a/Docs/DEPLOYMENT.md
+++ b/Docs/DEPLOYMENT.md
@@ -193,7 +193,9 @@ npm run dist        # current host platform default
 They expect a portable Host already published under
 `UniversalDeviceToolkit.Host/publish/osx-*` or `linux-x64`. `Release.yml`
 does not run them and does not attach DMG/AppImage/DEB assets to GitHub
-Releases.
+Releases. The manually dispatched `experimental-packages.yml` workflow (see
+[Experimental macOS/Linux release assets](#experimental-macoslinux-release-assets))
+can build and attach these experimental assets to an existing release tag.
 
 The packaging targets are defined in `UniversalDeviceToolkit.Electron/electron-builder.yml`:
 
@@ -209,8 +211,8 @@ The packaging targets are defined in `UniversalDeviceToolkit.Electron/electron-b
 |---|---|---|
 | Windows Full | `UniversalDeviceToolkitSetup-<version>.exe` (offline NSIS) | Yes |
 | Windows Online | `UniversalDeviceToolkitOnlineSetup-<version>.exe` (nsis-web stub, <= 15MB) plus `*.nsis.7z` payload | Yes |
-| macOS (experimental) | `UniversalDeviceToolkit-<version>-mac-arm64.dmg` / `-mac-x64.dmg` | No |
-| Linux (experimental) | `UniversalDeviceToolkit-<version>-linux-x64.AppImage` / `.deb` | No |
+| macOS (experimental) | `UniversalDeviceToolkit-<version>-mac-arm64.dmg` / `-mac-x64.dmg` | Optional experimental asset via `experimental-packages.yml` |
+| Linux (experimental) | `UniversalDeviceToolkit-<version>-linux-x86_64.AppImage` / `-linux-amd64.deb` | Optional experimental asset via `experimental-packages.yml` |
 
 #### Release footprint gate
 
@@ -271,6 +273,32 @@ local Windows builds are unsigned.
 `electron-builder.yml` already lists `AppImage` and `deb` (x64) as local
 targets. Neither is published by `Release.yml`. Adding `.rpm` or `.snap`
 would still be experimental local packaging, not an official product.
+
+### Experimental macOS/Linux release assets
+
+`.github/workflows/experimental-packages.yml` is a manually dispatched
+(`workflow_dispatch`) workflow that builds the experimental macOS DMGs
+(arm64 + x64, unsigned/not notarized) and Linux AppImage/DEB (x64, unsigned)
+for an **existing** `vX.Y.Z` release tag. It reuses the same pipeline as
+`package-footprint.yml` per platform: publish + prune the self-contained
+Host, smoke the Host JSON-RPC, `npm run typecheck` / `npm test` /
+`npm run build`, package with electron-builder, and enforce the distributable
+footprint budgets.
+
+Inputs:
+
+- `release_tag` (required): existing `vX.Y.Z` tag; the workflow fails if the
+  tag version does not match `Directory.Build.props`.
+- `attach_to_release` (default `false`): when `true`, uploads the DMG,
+  AppImage, and DEB assets plus a
+  `UniversalDeviceToolkit_v<version>_Experimental_SHA256.txt` manifest to
+  that GitHub release. When `false`, artifacts are only uploaded as workflow
+  run artifacts for inspection.
+
+This workflow never creates releases or tags and never touches the official
+Windows assets. The attached assets remain experimental: unsigned, without
+auto-update support, and without hardware control (the portable Host stubs
+Windows-only RPC). `Release.yml` remains the only official release pipeline.
 
 ### Known Platform Differences
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a manually dispatched GitHub Actions workflow to build and optionally attach experimental macOS/Linux Electron packages to an existing `vX.Y.Z` release.

## What changed

- **`.github/workflows/experimental-packages.yml`**: `workflow_dispatch` workflow that mirrors the proven `package-footprint.yml` pipeline for `linux-x64` (AppImage + deb) and `osx-arm64` / `osx-x64` (DMG). Validates the tag against `Directory.Build.props`, runs Host publish + prune, JSON-RPC smoke, Electron typecheck/tests/build, footprint budgets, and optionally uploads artifacts plus `UniversalDeviceToolkit_v<ver>_Experimental_SHA256.txt` to the target release.
- **`Docs/DEPLOYMENT.md`**: Documents the workflow and corrects Linux artifact naming to match electron-builder output (`-linux-x86_64.AppImage`, `-linux-amd64.deb`).
- **`CHANGELOG.md`**: `[Unreleased]` entry.

## Validation

- Linux packages built and audited locally on `93c0e7db9`: AppImage/deb pass footprint budgets; Host smoke + 181/181 Electron tests pass (Node 22.23+).
- macOS DMG jobs pass on CI run [#33286731530](https://github.com/SSC-STUDIO/UniversalDeviceToolkit/actions/runs/33286731530) for the same commit.

## How to publish experimental assets for v6.0.0

After merge: Actions → **Experimental Packages** → `release_tag=v6.0.0`, `attach_to_release=true`.

## Notes

- Does **not** modify `Release.yml` (Windows remains the only official signed release path).
- macOS DMGs are unsigned/not notarized; Linux packages are unsigned.
- Code review flagged a pre-existing medium issue in the Windows online installer download path (third-party mirrors without SHA256 verification); out of scope for this PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-400e6e32-a56a-4289-a1ff-51e17521bab3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-400e6e32-a56a-4289-a1ff-51e17521bab3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

