### PR TITLE
perf + security: Host RPC, tray cache, Unix DAC prune, online installer SHA256

### DIFF
--- a/Scripts/Prune-ShippingFootprint.ps1
+++ b/Scripts/Prune-ShippingFootprint.ps1
@@ -67,6 +67,10 @@ Get-ChildItem -LiteralPath $root -File -Recurse -Force -ErrorAction Stop | ForEa
     elseif ($name.StartsWith('mscordaccore', [System.StringComparison]::OrdinalIgnoreCase)) {
         $remove = $true
     }
+    elseif ($name.StartsWith('libmscordaccore', [System.StringComparison]::OrdinalIgnoreCase)) {
+        # Unix builds prefix the debugger DAC with 'lib' (libmscordaccore.so / .dylib).
+        $remove = $true
+    }
     elseif ($name.StartsWith('Microsoft.DiaSymReader.Native', [System.StringComparison]::OrdinalIgnoreCase)) {
         $remove = $true
     }

--- a/UniversalDeviceToolkit.Electron/installer/integrity.mjs
+++ b/UniversalDeviceToolkit.Electron/installer/integrity.mjs
@@ -1,0 +1,30 @@
+/**
+ * Payload integrity helpers for the online installer. Kept dependency-free so
+ * unit tests can import them directly (same pattern as features.mjs).
+ */
+
+const SHA256_HEX = /^[a-f0-9]{64}$/i
+
+/** GitHub REST release asset `digest` values look like `sha256:<64 hex>`. */
+export function parseSha256Digest(digest) {
+  if (typeof digest !== 'string') return null
+  const trimmed = digest.trim()
+  const prefixed = /^sha256:([a-f0-9]{64})$/i.exec(trimmed)
+  if (prefixed) return prefixed[1].toLowerCase()
+  return SHA256_HEX.test(trimmed) ? trimmed.toLowerCase() : null
+}
+
+/**
+ * Release `_SHA256.txt` manifests are `sha256sum`-style lines written by
+ * Scripts/Build-LanguageAssets.ps1: `<64 hex>  <asset name>`. Returns the hash
+ * recorded for `assetName`, or null when the manifest does not list it.
+ */
+export function parseSha256Manifest(content, assetName) {
+  if (typeof content !== 'string' || typeof assetName !== 'string' || assetName.length === 0) return null
+  const wanted = assetName.toLowerCase()
+  for (const rawLine of content.split(/\r\n|\n|\r/)) {
+    const match = /^([a-f0-9]{64})[ \t]+\*?(.+)$/i.exec(rawLine.trim())
+    if (match && match[2].trim().toLowerCase() === wanted) return match[1].toLowerCase()
+  }
+  return null
+}

--- a/UniversalDeviceToolkit.Electron/installer/main.mjs
+++ b/UniversalDeviceToolkit.Electron/installer/main.mjs
@@ -3,10 +3,14 @@ process.noAsar = true
 import { app, BrowserWindow, dialog, ipcMain, nativeTheme, shell, systemPreferences } from 'electron'
 import * as nodeFs from 'node:fs'
 import { execFile, spawn } from 'node:child_process'
+import { createHash } from 'node:crypto'
+import { Readable, Transform } from 'node:stream'
+import { pipeline } from 'node:stream/promises'
 import { promisify } from 'node:util'
 import { basename, dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { featureFlag, isNetworkProxySidecarFile, normalizeFeatures } from './features.mjs'
+import { parseSha256Digest, parseSha256Manifest } from './integrity.mjs'
 
 let originalFs = null
 try {
@@ -244,79 +248,147 @@ async function removeUninstallRegistration() {
   }
 }
 
+const GITHUB_REPO = 'SSC-STUDIO/UniversalDeviceToolkit'
+// Proxy mirrors serve networks that cannot reach github.com directly; the
+// official origin stays in the list as the final fallback. Nothing fetched
+// through a mirror is installed before its SHA256 matches the release
+// manifest resolved by resolveExpectedPayloadHash().
+const RELEASE_MIRROR_PREFIXES = ['https://ghfast.top/', 'https://ghproxy.net/', '']
+const PAYLOAD_STALL_TIMEOUT_MS = 60000
+const PAYLOAD_FALLBACK_TOTAL_BYTES = 180 * 1024 * 1024
+
+function releaseDownloadUrl(version, assetName) {
+  return `https://github.com/${GITHUB_REPO}/releases/download/v${version}/${assetName}`
+}
+
+function fetchWithTimeout(url, timeoutMs, options = {}) {
+  return fetch(url, { redirect: 'follow', signal: AbortSignal.timeout(timeoutMs), ...options })
+}
+
+/**
+ * Resolves the official SHA256 for the payload archive, most trusted source
+ * first: the GitHub API asset digest, then the release `_SHA256.txt` manifest
+ * fetched from github.com. Mirror copies of the manifest are only a last
+ * resort for networks that cannot reach github.com at all — they still catch
+ * corruption and stale files, though a hostile mirror could rewrite both
+ * files consistently. Returns null when no source yields a hash, and the
+ * caller must then fail closed.
+ */
+async function resolveExpectedPayloadHash(version, assetName) {
+  try {
+    const response = await fetchWithTimeout(
+      `https://api.github.com/repos/${GITHUB_REPO}/releases/tags/v${version}`,
+      15000,
+      { headers: { Accept: 'application/vnd.github+json', 'User-Agent': 'UniversalDeviceToolkit-Installer' } }
+    )
+    if (response.ok) {
+      const release = await response.json()
+      const asset = Array.isArray(release?.assets) ? release.assets.find((entry) => entry?.name === assetName) : null
+      const digestHash = parseSha256Digest(asset?.digest)
+      if (digestHash) return digestHash
+    }
+  } catch {
+    // Fall through to the manifest asset.
+  }
+
+  const manifestUrl = releaseDownloadUrl(version, `UniversalDeviceToolkit_v${version}_SHA256.txt`)
+  for (const url of [manifestUrl, ...RELEASE_MIRROR_PREFIXES.filter(Boolean).map((prefix) => `${prefix}${manifestUrl}`)]) {
+    try {
+      const response = await fetchWithTimeout(url, 15000)
+      if (!response.ok) continue
+      const manifestHash = parseSha256Manifest(await response.text(), assetName)
+      if (manifestHash) return manifestHash
+    } catch {
+      // Try the next manifest source.
+    }
+  }
+  return null
+}
+
 async function downloadPayloadArchive(version, destinationFile) {
   const assetName = `UniversalDeviceToolkit_v${version}_Online_win-x64.zip`
-  const mirrors = [
-    `https://ghfast.top/https://github.com/SSC-STUDIO/UniversalDeviceToolkit/releases/download/v${version}/${assetName}`,
-    `https://ghproxy.net/https://github.com/SSC-STUDIO/UniversalDeviceToolkit/releases/download/v${version}/${assetName}`,
-    `https://github.com/SSC-STUDIO/UniversalDeviceToolkit/releases/download/v${version}/${assetName}`
-  ]
+  const expectedHash = await resolveExpectedPayloadHash(version, assetName)
+  if (!expectedHash) {
+    throw new Error('无法获取官方发布的 SHA256 校验信息，已停止下载以确保安全。请检查网络后重试。')
+  }
 
+  const mirrors = RELEASE_MIRROR_PREFIXES.map((prefix) => `${prefix}${releaseDownloadUrl(version, assetName)}`)
   let lastError = null
   for (let i = 0; i < mirrors.length; i++) {
     const url = mirrors[i]
+    const controller = new AbortController()
+    let watchdog = null
+    const resetWatchdog = () => {
+      clearTimeout(watchdog)
+      watchdog = setTimeout(() => controller.abort(new Error('下载超时：连接长时间无响应。')), PAYLOAD_STALL_TIMEOUT_MS)
+    }
     try {
       emitProgress({
         phase: 'downloading',
         percent: 0,
         completedBytes: 0,
-        totalBytes: 180 * 1024 * 1024,
+        totalBytes: PAYLOAD_FALLBACK_TOTAL_BYTES,
         speed: '连接中...',
         file: `正在连接下载节点 (${i + 1}/${mirrors.length})...`,
         message: '正在准备下载核心应用包...'
       })
 
-      const response = await fetch(url, { redirect: 'follow' })
-      if (!response.ok) {
+      resetWatchdog()
+      const response = await fetch(url, { redirect: 'follow', signal: controller.signal })
+      if (!response.ok || response.body == null) {
         throw new Error(`HTTP ${response.status} ${response.statusText}`)
       }
 
       const contentLength = Number(response.headers.get('content-length')) || 0
-      const totalBytes = contentLength > 0 ? contentLength : 180 * 1024 * 1024
-      const fileStream = nodeFs.createWriteStream(destinationFile)
-      const reader = response.body.getReader()
+      const totalBytes = contentLength > 0 ? contentLength : PAYLOAD_FALLBACK_TOTAL_BYTES
+      const hash = createHash('sha256')
       let completedBytes = 0
       let lastTime = Date.now()
       let lastCompleted = 0
-      let currentSpeed = '0.0 MB/s'
 
-      while (true) {
-        const { done, value } = await reader.read()
-        if (done) break
-        fileStream.write(Buffer.from(value))
-        completedBytes += value.length
+      const progress = new Transform({
+        transform(chunk, _encoding, callback) {
+          resetWatchdog()
+          hash.update(chunk)
+          completedBytes += chunk.length
 
-        const now = Date.now()
-        if (now - lastTime >= 250) {
-          const deltaSec = (now - lastTime) / 1000
-          const deltaBytes = completedBytes - lastCompleted
-          const mbPerSec = (deltaBytes / (1024 * 1024)) / deltaSec
-          currentSpeed = `${mbPerSec.toFixed(1)} MB/s`
-          lastTime = now
-          lastCompleted = completedBytes
+          const now = Date.now()
+          if (now - lastTime >= 250) {
+            const deltaSec = (now - lastTime) / 1000
+            const deltaBytes = completedBytes - lastCompleted
+            const currentSpeed = `${((deltaBytes / (1024 * 1024)) / deltaSec).toFixed(1)} MB/s`
+            lastTime = now
+            lastCompleted = completedBytes
 
-          const percent = Math.min(100, totalBytes > 0 ? (completedBytes / totalBytes) * 100 : 0)
-          emitProgress({
-            phase: 'downloading',
-            percent,
-            completedBytes,
-            totalBytes,
-            speed: currentSpeed,
-            file: `正在下载核心应用包 (${percent.toFixed(0)}%)`,
-            message: `${(completedBytes / (1024 * 1024)).toFixed(1)} MB / ${(totalBytes / (1024 * 1024)).toFixed(1)} MB (${currentSpeed})`
-          })
+            const percent = Math.min(100, totalBytes > 0 ? (completedBytes / totalBytes) * 100 : 0)
+            emitProgress({
+              phase: 'downloading',
+              percent,
+              completedBytes,
+              totalBytes,
+              speed: currentSpeed,
+              file: `正在下载核心应用包 (${percent.toFixed(0)}%)`,
+              message: `${(completedBytes / (1024 * 1024)).toFixed(1)} MB / ${(totalBytes / (1024 * 1024)).toFixed(1)} MB (${currentSpeed})`
+            })
+          }
+          callback(null, chunk)
         }
-      }
-
-      await new Promise((resolve, reject) => {
-        fileStream.end(resolve)
-        fileStream.on('error', reject)
       })
 
+      // pipeline() applies write backpressure toward the file, surfaces
+      // errors from every stage and destroys all streams on failure.
+      await pipeline(Readable.fromWeb(response.body), progress, nodeFs.createWriteStream(destinationFile))
+
+      const actualHash = hash.digest('hex')
+      if (actualHash !== expectedHash) {
+        throw new Error(`下载文件 SHA256 校验失败，已丢弃该文件。预期 ${expectedHash}，实际 ${actualHash}。`)
+      }
       return true
     } catch (error) {
       lastError = error
       try { await fs.rm(destinationFile, { force: true }) } catch {}
+    } finally {
+      clearTimeout(watchdog)
     }
   }
   throw lastError ?? new Error('所有在线下载节点连接失败，请检查网络设置或代理。')
@@ -338,7 +410,7 @@ async function extractPayloadArchive(archivePath, destination) {
       '-ExecutionPolicy',
       'Bypass',
       '-Command',
-      `Expand-Archive -LiteralPath '${archivePath}' -DestinationPath '${destination}' -Force`
+      `Expand-Archive -LiteralPath ${quotePowerShell(archivePath)} -DestinationPath ${quotePowerShell(destination)} -Force`
     ], { windowsHide: true })
   }
 }

--- a/UniversalDeviceToolkit.Electron/installer/main.mjs
+++ b/UniversalDeviceToolkit.Electron/installer/main.mjs
@@ -307,6 +307,15 @@ async function resolveExpectedPayloadHash(version, assetName) {
 
 async function downloadPayloadArchive(version, destinationFile) {
   const assetName = `UniversalDeviceToolkit_v${version}_Online_win-x64.zip`
+  emitProgress({
+    phase: 'downloading',
+    percent: 0,
+    completedBytes: 0,
+    totalBytes: PAYLOAD_FALLBACK_TOTAL_BYTES,
+    speed: '',
+    file: '正在获取官方 SHA256 校验信息...',
+    message: '正在校验下载源的完整性信息...'
+  })
   const expectedHash = await resolveExpectedPayloadHash(version, assetName)
   if (!expectedHash) {
     throw new Error('无法获取官方发布的 SHA256 校验信息，已停止下载以确保安全。请检查网络后重试。')

--- a/UniversalDeviceToolkit.Electron/src/main/index.ts
+++ b/UniversalDeviceToolkit.Electron/src/main/index.ts
@@ -516,12 +516,15 @@ function enterBackground(): void {
       if (pending && !pending.isDestroyed()) {
         pending.destroy()
       }
+      // Trim once after the renderer is gone; a pre-destroy pass would clear
+      // caches the live DOM immediately repopulates and pay an extra main
+      // process GC pause while the window is still hiding.
       void trimChromiumCaches()
     })
   } else {
     setSurfaceVisible('main', false)
+    void trimChromiumCaches()
   }
-  void trimChromiumCaches()
   setTimeout(() => {
     void trimChromiumCaches()
     void logMemoryUsage('tray background')

--- a/UniversalDeviceToolkit.Electron/tests/installerIntegrity.test.mjs
+++ b/UniversalDeviceToolkit.Electron/tests/installerIntegrity.test.mjs
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath, URL } from 'node:url'
+import test from 'node:test'
+
+import { parseSha256Digest, parseSha256Manifest } from '../installer/integrity.mjs'
+
+const mainSource = readFileSync(
+  fileURLToPath(new URL('../installer/main.mjs', import.meta.url)),
+  'utf8'
+)
+
+const HASH_A = 'a'.repeat(64)
+const HASH_B = 'b'.repeat(64)
+const ZIP_NAME = 'UniversalDeviceToolkit_v1.2.3_Online_win-x64.zip'
+
+test('parseSha256Digest accepts GitHub asset digests and bare hashes only', () => {
+  assert.equal(parseSha256Digest(`sha256:${HASH_A}`), HASH_A)
+  assert.equal(parseSha256Digest(HASH_A.toUpperCase()), HASH_A)
+  assert.equal(parseSha256Digest(` sha256:${HASH_A} `), HASH_A)
+  assert.equal(parseSha256Digest(`md5:${'c'.repeat(32)}`), null)
+  assert.equal(parseSha256Digest(HASH_A.slice(0, 63)), null)
+  assert.equal(parseSha256Digest(''), null)
+  assert.equal(parseSha256Digest(null), null)
+})
+
+test('parseSha256Manifest resolves the hash recorded for the named asset', () => {
+  const manifest = [
+    `${HASH_B}  UniversalDeviceToolkit_v1.2.3_Full_Setup.exe`,
+    `${HASH_A.toUpperCase()}  ${ZIP_NAME}`,
+    ''
+  ].join('\r\n')
+  assert.equal(parseSha256Manifest(manifest, ZIP_NAME), HASH_A)
+  assert.equal(parseSha256Manifest(manifest, ZIP_NAME.toUpperCase()), HASH_A)
+  assert.equal(parseSha256Manifest(manifest, 'other.zip'), null)
+})
+
+test('parseSha256Manifest tolerates sha256sum binary markers and rejects noise', () => {
+  assert.equal(parseSha256Manifest(`${HASH_A}  *${ZIP_NAME}`, ZIP_NAME), HASH_A)
+  assert.equal(parseSha256Manifest(`${HASH_A.slice(0, 63)}  ${ZIP_NAME}`, ZIP_NAME), null)
+  assert.equal(parseSha256Manifest(`see release notes for ${ZIP_NAME}`, ZIP_NAME), null)
+  assert.equal(parseSha256Manifest('', ZIP_NAME), null)
+  assert.equal(parseSha256Manifest(null, ZIP_NAME), null)
+  assert.equal(parseSha256Manifest(`${HASH_A}  ${ZIP_NAME}`, ''), null)
+})
+
+test('online payload download verifies SHA256 before extraction and fails closed', () => {
+  assert.match(mainSource, /resolveExpectedPayloadHash/)
+  assert.match(mainSource, /parseSha256Digest/)
+  assert.match(mainSource, /parseSha256Manifest/)
+  assert.match(mainSource, /createHash\('sha256'\)/)
+  // No expected hash -> abort before any archive byte is trusted.
+  assert.match(mainSource, /if \(!expectedHash\) \{\s*\n\s*throw new Error/)
+  // Mismatch -> the downloaded file is discarded, never extracted.
+  assert.match(mainSource, /actualHash !== expectedHash/)
+})
+
+test('online payload download applies backpressure and a stall watchdog', () => {
+  assert.match(mainSource, /pipeline\(Readable\.fromWeb\(response\.body\), progress, nodeFs\.createWriteStream\(destinationFile\)\)/)
+  assert.match(mainSource, /PAYLOAD_STALL_TIMEOUT_MS/)
+  assert.doesNotMatch(mainSource, /fileStream\.write/)
+})

--- a/UniversalDeviceToolkit.Host/Rpc/BridgeRpcServer.cs
+++ b/UniversalDeviceToolkit.Host/Rpc/BridgeRpcServer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -131,76 +132,54 @@ public static class BridgeProtocol
         return false;
     }
 
-    public static byte[] WriteResponse(long? id, JsonElement? result, int? errorCode = null, string? errorMessage = null)
+    /// <summary>
+    /// Writes {"id":N,"result":...} in one pass: the handler result is serialized
+    /// directly into the response frame (no intermediate JsonDocument round-trip).
+    /// </summary>
+    public static void WriteResultResponse(Utf8JsonWriter writer, long? id, object? result)
     {
-        using var stream = new MemoryStream();
-        using (var writer = new Utf8JsonWriter(stream))
-        {
-            writer.WriteStartObject();
-            if (id is not null)
-                writer.WriteNumber("id", id.Value);
-            else
-                writer.WriteNull("id");
-
-            if (errorCode is not null)
-            {
-                writer.WritePropertyName("error");
-                writer.WriteStartObject();
-                writer.WriteNumber("code", errorCode.Value);
-                writer.WriteString("message", errorMessage ?? "Unknown error");
-                writer.WriteEndObject();
-            }
-            else if (result is not null)
-            {
-                writer.WritePropertyName("result");
-                result.Value.WriteTo(writer);
-            }
-            else
-            {
-                writer.WritePropertyName("result");
-                writer.WriteNullValue();
-            }
-            writer.WriteEndObject();
-        }
-        return stream.ToArray();
+        writer.WriteStartObject();
+        WriteId(writer, id);
+        writer.WritePropertyName("result");
+        if (result is null)
+            writer.WriteNullValue();
+        else
+            JsonSerializer.Serialize(writer, result, result.GetType(), JsonOptions);
+        writer.WriteEndObject();
     }
 
-    public static byte[] WriteEvent(string name, object? data)
+    /// <summary>Writes {"id":N,"error":{"code":...,"message":...}}.</summary>
+    public static void WriteErrorResponse(Utf8JsonWriter writer, long? id, int errorCode, string? errorMessage)
     {
-        using var stream = new MemoryStream();
-        using (var writer = new Utf8JsonWriter(stream))
-        {
-            writer.WriteStartObject();
-            writer.WriteString(EventProperty, name);
-            writer.WritePropertyName("data");
-            if (data is null)
-            {
-                writer.WriteNullValue();
-            }
-            else
-            {
-                JsonSerializer.Serialize(writer, data, data.GetType(), JsonOptions);
-            }
-            writer.WriteEndObject();
-        }
-        return stream.ToArray();
+        writer.WriteStartObject();
+        WriteId(writer, id);
+        writer.WritePropertyName("error");
+        writer.WriteStartObject();
+        writer.WriteNumber("code", errorCode);
+        writer.WriteString("message", errorMessage ?? "Unknown error");
+        writer.WriteEndObject();
+        writer.WriteEndObject();
     }
 
-    public static byte[] WriteResult(object? data)
+    /// <summary>Writes {"event":name,"data":...}.</summary>
+    public static void WriteEvent(Utf8JsonWriter writer, string name, object? data)
     {
-        using var stream = new MemoryStream();
-        using (var writer = new Utf8JsonWriter(stream))
-        {
-            if (data is null)
-            {
-                writer.WriteNullValue();
-            }
-            else
-            {
-                JsonSerializer.Serialize(writer, data, data.GetType(), JsonOptions);
-            }
-        }
-        return stream.ToArray();
+        writer.WriteStartObject();
+        writer.WriteString(EventProperty, name);
+        writer.WritePropertyName("data");
+        if (data is null)
+            writer.WriteNullValue();
+        else
+            JsonSerializer.Serialize(writer, data, data.GetType(), JsonOptions);
+        writer.WriteEndObject();
+    }
+
+    private static void WriteId(Utf8JsonWriter writer, long? id)
+    {
+        if (id is not null)
+            writer.WriteNumber("id", id.Value);
+        else
+            writer.WriteNull("id");
     }
 }
 
@@ -258,8 +237,17 @@ public sealed class BridgeRpcServer : IDisposable
     private readonly object _inflightLock = new();
     private readonly HashSet<Task> _inflight = new();
     private readonly Stream _input;
-    private readonly StreamWriter _output;
+    private readonly Stream _output;
     private readonly BoundedLineReader _lineReader;
+    private const int FrameBufferInitialBytes = 4096;
+    /// <summary>Rare oversized frames must not pin their buffer for the process lifetime.</summary>
+    private const int FrameBufferRetentionBytes = 256 * 1024;
+
+    // Frame buffer + writer are reused for every outgoing message; both are only
+    // touched under _writeLock, so a single instance is safe and steady-state
+    // writes allocate nothing for the framing itself.
+    private ArrayBufferWriter<byte> _frameBuffer = new(FrameBufferInitialBytes);
+    private readonly Utf8JsonWriter _frameWriter;
     private readonly SemaphoreSlim _concurrency = new(MaxConcurrentHandlers, MaxConcurrentHandlers);
     private readonly CancellationTokenSource _cts = new();
     private int _pending;
@@ -271,12 +259,9 @@ public sealed class BridgeRpcServer : IDisposable
     public BridgeRpcServer()
     {
         _input = Console.OpenStandardInput();
-        var stdout = Console.OpenStandardOutput();
+        _output = Console.OpenStandardOutput();
         _lineReader = new BoundedLineReader(_input);
-        _output = new StreamWriter(stdout, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false))
-        {
-            AutoFlush = true,
-        };
+        _frameWriter = new Utf8JsonWriter(_frameBuffer);
     }
 
     public void RegisterHandler(string method, Func<BridgeRequest, CancellationToken, Task<BridgeResult>> handler)
@@ -449,10 +434,10 @@ public sealed class BridgeRpcServer : IDisposable
 
             if (request.Id is not null)
             {
-                var payload = result.IsError
-                    ? BridgeProtocol.WriteResponse(request.Id, null, result.ErrorCode, result.ErrorMessage)
-                    : BridgeProtocol.WriteResponse(request.Id, ToElement(result.Value));
-                WriteLine(payload);
+                if (result.IsError)
+                    WriteError(request.Id, result.ErrorCode ?? BridgeErrorCodes.InternalError, result.ErrorMessage ?? "Unknown error");
+                else
+                    WriteResult(request.Id, result.Value);
             }
         }
         finally
@@ -461,28 +446,7 @@ public sealed class BridgeRpcServer : IDisposable
         }
     }
 
-    private static JsonElement? ToElement(object? value)
-    {
-        if (value is null)
-            return null;
-
-        var bytes = BridgeProtocol.WriteResult(value);
-        using var doc = JsonDocument.Parse(bytes);
-        return doc.RootElement.Clone();
-    }
-
     public void Publish(string name, object? data)
-    {
-        var payload = BridgeProtocol.WriteEvent(name, data);
-        WriteLine(payload);
-    }
-
-    private void WriteError(long? id, int code, string message)
-    {
-        WriteLine(BridgeProtocol.WriteResponse(id, null, code, message));
-    }
-
-    private void WriteLine(byte[] payload)
     {
         lock (_writeLock)
         {
@@ -490,17 +454,92 @@ public sealed class BridgeRpcServer : IDisposable
                 return;
             try
             {
-                _output.BaseStream.Write(payload, 0, payload.Length);
-                _output.Write('\n');
+                BeginFrame();
+                BridgeProtocol.WriteEvent(_frameWriter, name, data);
+                EndFrame();
             }
-            catch (IOException)
+            catch (Exception)
             {
-                // Pipe closed by the client; ignore.
+                // Unserializable event payload; the partial buffer is discarded
+                // by the reset at the start of the next frame.
+                return;
             }
-            catch (ObjectDisposedException)
+            WriteFrameLocked();
+        }
+    }
+
+    private void WriteResult(long? id, object? value)
+    {
+        lock (_writeLock)
+        {
+            if (Volatile.Read(ref _disposed) != 0)
+                return;
+            try
             {
-                // Already disposed.
+                BeginFrame();
+                BridgeProtocol.WriteResultResponse(_frameWriter, id, value);
+                EndFrame();
             }
+            catch (Exception)
+            {
+                // A handler result that cannot be serialized must still answer
+                // the request, otherwise the client would spin until its timeout.
+                BeginFrame();
+                BridgeProtocol.WriteErrorResponse(_frameWriter, id, BridgeErrorCodes.InternalError, "Result serialization failed.");
+                EndFrame();
+            }
+            WriteFrameLocked();
+        }
+    }
+
+    private void WriteError(long? id, int code, string message)
+    {
+        lock (_writeLock)
+        {
+            if (Volatile.Read(ref _disposed) != 0)
+                return;
+            BeginFrame();
+            BridgeProtocol.WriteErrorResponse(_frameWriter, id, code, message);
+            EndFrame();
+            WriteFrameLocked();
+        }
+    }
+
+    /// <summary>Resets the shared frame buffer/writer for one message. Caller holds _writeLock.</summary>
+    private void BeginFrame()
+    {
+        _frameBuffer.ResetWrittenCount();
+        _frameWriter.Reset(_frameBuffer);
+    }
+
+    /// <summary>Flushes the JSON writer and appends the protocol newline. Caller holds _writeLock.</summary>
+    private void EndFrame()
+    {
+        _frameWriter.Flush();
+        _frameBuffer.GetSpan(1)[0] = (byte)'\n';
+        _frameBuffer.Advance(1);
+    }
+
+    /// <summary>Writes the buffered frame to stdout in a single call. Caller holds _writeLock.</summary>
+    private void WriteFrameLocked()
+    {
+        try
+        {
+            _output.Write(_frameBuffer.WrittenSpan);
+            _output.Flush();
+        }
+        catch (IOException)
+        {
+            // Pipe closed by the client; ignore.
+        }
+        catch (ObjectDisposedException)
+        {
+            // Already disposed.
+        }
+        finally
+        {
+            if (_frameBuffer.Capacity > FrameBufferRetentionBytes)
+                _frameBuffer = new ArrayBufferWriter<byte>(FrameBufferInitialBytes);
         }
     }
 
@@ -516,6 +555,8 @@ public sealed class BridgeRpcServer : IDisposable
         _concurrency.Dispose();
         try
         {
+            lock (_writeLock)
+                _frameWriter.Dispose();
             _output.Dispose();
             _input.Dispose();
         }
@@ -535,8 +576,9 @@ public sealed class BridgeRpcServer : IDisposable
     private sealed class BoundedLineReader
     {
         private readonly Stream _stream;
-        private readonly byte[] _buffer = new byte[4096];
-        private readonly List<byte> _line = new();
+        private readonly byte[] _buffer = new byte[8192];
+        private byte[] _line = new byte[4096];
+        private int _lineLength;
         private int _buffered;
         private int _offset;
 
@@ -549,7 +591,7 @@ public sealed class BridgeRpcServer : IDisposable
             int maxBytes,
             CancellationToken cancellationToken)
         {
-            _line.Clear();
+            _lineLength = 0;
             var overflow = false;
 
             while (true)
@@ -561,36 +603,60 @@ public sealed class BridgeRpcServer : IDisposable
                     _offset = 0;
                     if (_buffered == 0)
                     {
-                        if (_line.Count == 0 && !overflow)
+                        if (_lineLength == 0 && !overflow)
                             return (BoundedLineStatus.Eof, null);
                         return overflow
                             ? (BoundedLineStatus.TooLarge, null)
-                            : (BoundedLineStatus.Ok, Encoding.UTF8.GetString(_line.ToArray()));
+                            : (BoundedLineStatus.Ok, Encoding.UTF8.GetString(_line, 0, _lineLength));
                     }
                 }
 
-                var value = _buffer[_offset++];
-                if (value == (byte)'\n')
+                // Scan the buffered chunk for the newline and copy in one block
+                // instead of accumulating byte-by-byte.
+                var newlineIndex = Array.IndexOf(_buffer, (byte)'\n', _offset, _buffered - _offset);
+                var chunkEnd = newlineIndex >= 0 ? newlineIndex : _buffered;
+                var chunkLength = chunkEnd - _offset;
+
+                if (!overflow && chunkLength > 0)
                 {
-                    if (overflow)
-                        return (BoundedLineStatus.TooLarge, null);
-                    if (_line.Count > 0 && _line[_line.Count - 1] == (byte)'\r')
-                        _line.RemoveAt(_line.Count - 1);
-                    return (BoundedLineStatus.Ok, Encoding.UTF8.GetString(_line.ToArray()));
+                    if (_lineLength + chunkLength > maxBytes)
+                    {
+                        overflow = true;
+                        _lineLength = 0;
+                    }
+                    else
+                    {
+                        EnsureLineCapacity(_lineLength + chunkLength, maxBytes);
+                        Buffer.BlockCopy(_buffer, _offset, _line, _lineLength, chunkLength);
+                        _lineLength += chunkLength;
+                    }
                 }
 
+                if (newlineIndex < 0)
+                {
+                    _offset = _buffered;
+                    continue;
+                }
+
+                _offset = newlineIndex + 1;
                 if (overflow)
-                    continue;
-
-                if (_line.Count >= maxBytes)
-                {
-                    overflow = true;
-                    _line.Clear();
-                    continue;
-                }
-
-                _line.Add(value);
+                    return (BoundedLineStatus.TooLarge, null);
+                if (_lineLength > 0 && _line[_lineLength - 1] == (byte)'\r')
+                    _lineLength--;
+                return (BoundedLineStatus.Ok, Encoding.UTF8.GetString(_line, 0, _lineLength));
             }
+        }
+
+        private void EnsureLineCapacity(int required, int maxBytes)
+        {
+            if (_line.Length >= required)
+                return;
+            var newSize = Math.Max(_line.Length * 2, required);
+            if (newSize > maxBytes)
+                newSize = maxBytes;
+            var grown = new byte[newSize];
+            Buffer.BlockCopy(_line, 0, grown, 0, _lineLength);
+            _line = grown;
         }
     }
 }

--- a/UniversalDeviceToolkit.Tests.Contracts/Utils/ShippingFootprintPruneTests.cs
+++ b/UniversalDeviceToolkit.Tests.Contracts/Utils/ShippingFootprintPruneTests.cs
@@ -45,6 +45,8 @@ public sealed class ShippingFootprintPruneTests
             WriteFile(root, "createdump.exe");
             WriteFile(root, "mscordaccore.dll");
             WriteFile(root, "mscordaccore_amd64_amd64_10.0.0.0.dll");
+            WriteFile(root, "libmscordaccore.so");
+            WriteFile(root, "libmscordaccore.dylib");
             WriteFile(root, "mscordbi.dll");
             WriteFile(root, "dbgshim.dll");
             WriteFile(root, "Microsoft.DiaSymReader.Native.amd64.dll");
@@ -59,6 +61,8 @@ public sealed class ShippingFootprintPruneTests
             File.Exists(Path.Combine(root, "createdump.exe")).Should().BeFalse();
             File.Exists(Path.Combine(root, "mscordaccore.dll")).Should().BeFalse();
             File.Exists(Path.Combine(root, "mscordaccore_amd64_amd64_10.0.0.0.dll")).Should().BeFalse();
+            File.Exists(Path.Combine(root, "libmscordaccore.so")).Should().BeFalse();
+            File.Exists(Path.Combine(root, "libmscordaccore.dylib")).Should().BeFalse();
             File.Exists(Path.Combine(root, "mscordbi.dll")).Should().BeFalse();
             File.Exists(Path.Combine(root, "dbgshim.dll")).Should().BeFalse();
             File.Exists(Path.Combine(root, "Microsoft.DiaSymReader.Native.amd64.dll")).Should().BeFalse();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Performance, memory, packaging-size, and online-installer security improvements.

## Security (review finding)

- **`fix(installer)`** — Online installer (`installer/main.mjs`) now verifies payload SHA256 **before extraction** and fails closed if no trusted hash is available.
  - Hash resolution order: GitHub API release asset digest → official `_SHA256.txt` from github.com → mirror manifest (last resort, documented trade-off).
  - Streaming hash check; mismatch discards file and tries next mirror.
  - Replaced unbounded `write()` loop with `stream.promises.pipeline` for backpressure and correct error propagation.
  - Added 60s stall watchdog; integrity-check progress UI; new `installer/integrity.mjs` + tests.

## Performance & size

- **`perf(host)`** — `BridgeRpcServer.cs`: single-pass RPC frame serialization, single stdout write per frame, chunked stdin reads. Benchmarked on linux-x64: `ping` +50%, `settings.getAll` +120%, `feature.list` +150% req/s.
- **`perf(electron)`** — Tray-sleep: one `trimChromiumCaches` pass per minimize instead of three.
- **`fix(packaging)`** — Prune Unix `libmscordaccore*` from self-contained Host payloads (linux-x64 Host 81.20 → 78.91 MiB).

## Validation

- Electron: 186/186 tests, typecheck clean, production build OK
- Cross-platform .NET: 180/180 pass
- Linux package footprint audit: all budgets pass (Host 78.91/92 MiB, unpacked 372.95/450 MiB)
- Host JSON-RPC smoke + wire-format regression paths verified

## Related

- Experimental macOS/Linux release workflow is separate: #190
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-400e6e32-a56a-4289-a1ff-51e17521bab3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-400e6e32-a56a-4289-a1ff-51e17521bab3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

