### PR TITLE
perf(renderer): minify, split antd, lazy-load echarts (incomplete leftover)

### DIFF
--- a/UniversalDeviceToolkit.Electron/electron.vite.config.ts
+++ b/UniversalDeviceToolkit.Electron/electron.vite.config.ts
@@ -3,8 +3,15 @@ import { defineConfig } from 'electron-vite'
 import react from '@vitejs/plugin-react'
 
 export default defineConfig({
-  main: {},
-  preload: {},
+  // electron-vite defaults to minify:false for every target; the app ships
+  // production bundles inside app.asar, so minified output directly cuts both
+  // package size and V8 parse time at startup.
+  main: {
+    build: { minify: 'esbuild' }
+  },
+  preload: {
+    build: { minify: 'esbuild' }
+  },
   renderer: {
     resolve: {
       alias: {
@@ -13,20 +20,29 @@ export default defineConfig({
     },
     plugins: [react()],
     build: {
+      minify: 'esbuild',
       rollupOptions: {
         output: {
           // Split only modules that are already in the module graph. Naming a
           // barrel package (especially @fluentui/react-icons) as a chunk entry
           // can pull the entire export surface into the renderer.
           manualChunks(id) {
-            if (id.includes('node_modules/echarts')) return 'charts'
+            // echarts + its zrender engine load together, and only when a
+            // trend chart actually mounts (utils/echarts.ts lazy loader).
+            if (id.includes('node_modules/echarts') || id.includes('node_modules/zrender')) {
+              return 'charts'
+            }
             if (id.includes('node_modules/@fluentui/react-icons')) return 'icons'
+            // Keep the truly startup-critical framework in one eager chunk.
+            // antd intentionally has no manual assignment: Rollup then splits
+            // it by consumer, so components used only by lazy routes (Select,
+            // Slider, Tabs, ColorPicker, ...) stay out of the startup graph
+            // instead of being hoisted into an eagerly parsed vendor chunk.
             if (
-              id.includes('node_modules/antd') ||
-              id.includes('node_modules/@ant-design') ||
               id.includes('node_modules/react-dom') ||
               id.includes('node_modules/react-router') ||
-              id.includes('node_modules/react/')
+              id.includes('node_modules/react/') ||
+              id.includes('node_modules/scheduler')
             ) {
               return 'vendor'
             }

--- a/UniversalDeviceToolkit.Electron/src/renderer/src/App.tsx
+++ b/UniversalDeviceToolkit.Electron/src/renderer/src/App.tsx
@@ -1,6 +1,6 @@
 import { Suspense, lazy, type ReactNode } from 'react'
-import { Spin } from 'antd'
 import { Navigate, Route, Routes } from 'react-router-dom'
+import { ArrowSync24Regular, FluentIcon } from './components/icons/fluent'
 import { isInstallerOptionalFeatureEnabled, type InstallerOptionalFeature } from '../../shared/installer-selection'
 import { CapabilityGate } from './layout/CapabilityRedirect'
 import AppLayout from './layout/AppLayout'
@@ -13,10 +13,14 @@ const MacroPage = lazy(() => import('./pages/MacroPage'))
 const WindowsOptimizationPage = lazy(() => import('./pages/WindowsOptimizationPage'))
 const AboutPage = lazy(() => import('./pages/AboutPage'))
 
+// Fluent spinner instead of antd Spin: the route fallback is on the eager
+// startup path, and this keeps antd component code out of the entry chunk.
 function PageFallback(): React.JSX.Element {
   return (
     <div style={{ display: 'flex', justifyContent: 'center', padding: 48 }}>
-      <Spin size="large" />
+      <FluentIcon size={32} spin color="var(--udt-accent-secondary)">
+        <ArrowSync24Regular />
+      </FluentIcon>
     </div>
   )
 }

--- a/UniversalDeviceToolkit.Electron/src/renderer/src/components/TitleBar.tsx
+++ b/UniversalDeviceToolkit.Electron/src/renderer/src/components/TitleBar.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react'
-import { Tooltip } from 'antd'
 import { useTranslation } from 'react-i18next'
 import { useLocation } from 'react-router-dom'
 import { invoke, on } from '../api/bridge'
@@ -97,28 +96,28 @@ export default function TitleBar(): React.JSX.Element {
         </span>
         {/* Right chrome: Log + device stay immediately before caption buttons (Electron parity). */}
         <div className="udt-titlebar__chrome" style={NO_DRAG_STYLE}>
+          {/* Native title tooltips: antd Tooltip here would pull the rc-trigger
+              stack into the eager titlebar bundle for two hover hints. */}
           <div className="udt-titlebar__trailing">
-            <Tooltip title={t('titlebar.openLogs')}>
+            <button
+              type="button"
+              className="udt-titlebar__log-button"
+              title={t('titlebar.openLogs')}
+              aria-label={t('titlebar.openLogs')}
+              onClick={openLogFolder}
+            >
+              {t('titlebar.log')}
+            </button>
+            <div className="udt-titlebar__device-slot">
               <button
                 type="button"
-                className="udt-titlebar__log-button"
-                aria-label={t('titlebar.openLogs')}
-                onClick={openLogFolder}
+                className="udt-titlebar__device-button"
+                title={t('titlebar.deviceInfo')}
+                aria-label={t('titlebar.deviceInfo')}
+                onClick={() => setDeviceInfoOpen(true)}
               >
-                {t('titlebar.log')}
+                {deviceModel ?? t('titlebar.deviceName')}
               </button>
-            </Tooltip>
-            <div className="udt-titlebar__device-slot">
-              <Tooltip title={t('titlebar.deviceInfo')}>
-                <button
-                  type="button"
-                  className="udt-titlebar__device-button"
-                  aria-label={t('titlebar.deviceInfo')}
-                  onClick={() => setDeviceInfoOpen(true)}
-                >
-                  {deviceModel ?? t('titlebar.deviceName')}
-                </button>
-              </Tooltip>
             </div>
           </div>
           {!isMac && (

--- a/UniversalDeviceToolkit.Electron/src/renderer/src/components/dashboard/TrendChart.tsx
+++ b/UniversalDeviceToolkit.Electron/src/renderer/src/components/dashboard/TrendChart.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useRef } from 'react'
-import { init, type ECharts, type EChartsCoreOption } from '../../utils/echarts'
+import { useEffect, useRef, useState } from 'react'
+import { loadECharts, type ECharts, type EChartsCoreOption } from '../../utils/echarts'
 import { useThemeStore } from '../../stores/themeStore'
 
 export interface TrendSeries {
@@ -48,7 +48,9 @@ export default function TrendChart({
   emptyLabel
 }: TrendChartProps): React.JSX.Element {
   const containerRef = useRef<HTMLDivElement>(null)
-  const chartRef = useRef<ECharts | null>(null)
+  // State (not a ref) so the option effects below re-run once the lazily
+  // imported echarts runtime finishes loading and the instance exists.
+  const [chart, setChart] = useState<ECharts | null>(null)
   const isDark = useThemeStore((s) => s.themeMode === 'dark')
   // Electron _smoothedAutoMax: auto-scaled series converge toward the observed max
   // instead of jumping (rise fast, fall slow).
@@ -64,29 +66,36 @@ export default function TrendChart({
   useEffect(() => {
     const el = containerRef.current
     if (!el) return
-    // devicePixelRatio keeps output crisp on HiDPI displays and under the
-    // main-process zoom factor (SVG today, but harmless and future-proof if
-    // the renderer switches to canvas).
-    const chart = init(el, undefined, { devicePixelRatio: window.devicePixelRatio })
-    chartRef.current = chart
-    baseOptionRef.current = null
+    let disposed = false
+    let instance: ECharts | null = null
+    let observer: ResizeObserver | null = null
     const handleResize = (): void => {
-      chart.resize()
+      instance?.resize()
     }
-    window.addEventListener('resize', handleResize)
-    const observer = new ResizeObserver(handleResize)
-    observer.observe(el)
-    return () => {
-      window.removeEventListener('resize', handleResize)
-      observer.disconnect()
-      chart.dispose()
-      chartRef.current = null
+    void loadECharts().then(({ init }) => {
+      if (disposed) return
+      // devicePixelRatio keeps output crisp on HiDPI displays and under the
+      // main-process zoom factor (SVG today, but harmless and future-proof if
+      // the renderer switches to canvas).
+      instance = init(el, undefined, { devicePixelRatio: window.devicePixelRatio })
       baseOptionRef.current = null
+      window.addEventListener('resize', handleResize)
+      observer = new ResizeObserver(handleResize)
+      observer.observe(el)
+      setChart(instance)
+    })
+    return () => {
+      disposed = true
+      window.removeEventListener('resize', handleResize)
+      observer?.disconnect()
+      instance?.dispose()
+      instance = null
+      baseOptionRef.current = null
+      setChart(null)
     }
   }, [])
 
   useEffect(() => {
-    const chart = chartRef.current
     if (!chart) return
     const key = skeletonKey(series, isDark)
     if (baseOptionRef.current?.key === key) return
@@ -217,12 +226,11 @@ export default function TrendChart({
 
     baseOptionRef.current = { key, option }
     chart.setOption(option, { notMerge: true })
-  }, [series, isDark, labels])
+  }, [chart, series, isDark, labels])
 
   // Data-only update path: rebinds normalized data without rebuilding the
   // static option (grid, axes, area gradients, mark lines).
   useEffect(() => {
-    const chart = chartRef.current
     const base = baseOptionRef.current
     if (!chart || !base) return
 
@@ -256,7 +264,7 @@ export default function TrendChart({
       },
       { lazyUpdate: true }
     )
-  }, [series, labels, isDark])
+  }, [chart, series, labels, isDark])
 
   const waiting = emptyLabel != null && emptyLabel !== '' && !hasDrawableLine(series)
 

--- a/UniversalDeviceToolkit.Electron/src/renderer/src/utils/echarts.ts
+++ b/UniversalDeviceToolkit.Electron/src/renderer/src/utils/echarts.ts
@@ -1,34 +1,20 @@
 /**
- * Tree-shaken echarts registration — keeps the renderer bundle small by
- * importing only the chart types/components the app actually uses.
- *
- * SVGRenderer instead of CanvasRenderer: the sensor gauges and trend charts
- * are low-frequency (1 Hz) simple line/gauge visuals, and SVG keeps the DOM
- * smaller than a backing canvas — lower renderer memory. If a future chart
- * needs canvas (dense scatter, large data), swap the renderer here.
+ * Lazy facade over the echarts runtime. Only type imports are static (erased
+ * at compile time); the actual library is loaded on first use so the ~1.3 MB
+ * charts chunk never blocks page navigation or the dashboard's first paint.
  */
-import { use, type EChartsCoreOption, type EChartsType } from 'echarts/core'
-import { GaugeChart, LineChart } from 'echarts/charts'
-import {
-  GraphicComponent,
-  GridComponent,
-  MarkLineComponent,
-  TooltipComponent
-} from 'echarts/components'
-import { SVGRenderer } from 'echarts/renderers'
-
-use([
-  GaugeChart,
-  LineChart,
-  GridComponent,
-  TooltipComponent,
-  GraphicComponent,
-  MarkLineComponent,
-  SVGRenderer
-])
+import type { EChartsCoreOption, EChartsType } from 'echarts/core'
 
 export type ECharts = EChartsType
 export type EChartsOption = EChartsCoreOption
 export type { EChartsCoreOption }
 
-export { init } from 'echarts/core'
+export type EChartsRuntime = typeof import('./echartsRuntime')
+
+let runtimePromise: Promise<EChartsRuntime> | null = null
+
+/** Import and register the tree-shaken echarts runtime exactly once. */
+export function loadECharts(): Promise<EChartsRuntime> {
+  runtimePromise ??= import('./echartsRuntime')
+  return runtimePromise
+}

--- a/UniversalDeviceToolkit.Electron/src/renderer/src/utils/echartsRuntime.ts
+++ b/UniversalDeviceToolkit.Electron/src/renderer/src/utils/echartsRuntime.ts
@@ -1,0 +1,22 @@
+/**
+ * Tree-shaken echarts registration — static imports keep Rollup able to strip
+ * every chart type/component the app does not use. This module is only ever
+ * reached through the dynamic import in ./echarts.ts, so the whole echarts +
+ * zrender graph ("charts" chunk) stays out of the startup bundle and is
+ * fetched the first time a trend chart mounts.
+ *
+ * Registered set: TrendChart needs line series, the cartesian grid, the axis
+ * tooltip and markLine gridlines. Gauges are custom SVG (SensorGauge), so no
+ * GaugeChart. SVGRenderer instead of CanvasRenderer: the trend charts are
+ * low-frequency (1 Hz) simple line visuals, and SVG keeps renderer memory
+ * lower than a backing canvas. If a future chart needs canvas (dense scatter,
+ * large data), swap the renderer here.
+ */
+import { use } from 'echarts/core'
+import { LineChart } from 'echarts/charts'
+import { GridComponent, MarkLineComponent, TooltipComponent } from 'echarts/components'
+import { SVGRenderer } from 'echarts/renderers'
+
+use([LineChart, GridComponent, TooltipComponent, MarkLineComponent, SVGRenderer])
+
+export { init } from 'echarts/core'


### PR DESCRIPTION
Incomplete leftover from the interrupted size/perf agent, rebased onto current `master` (after #191 squash) so this is only the unmerged renderer work.

- Enable esbuild minify for main/preload/renderer
- Stop hoisting antd into the eager vendor chunk (lazy-route components stay out of startup)
- Lazy-load tree-shaken echarts on first `TrendChart` mount; new `echartsRuntime.ts`
- TitleBar: native `title` instead of antd Tooltip; route fallback uses Fluent spinner instead of antd Spin

Not finished (WMI/ICU and other size work never landed). Do not merge blindly.